### PR TITLE
feat(sqlalchemy): add SQLAlchemy state and lock backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,63 @@ You'll get a full list of jobs with:
 
 We use SQLite (via `aiosqlite`) to keep a persistent record of when each job last ran. This allows observability and resilience during restarts.
 
+## 🗄️ SQLAlchemy State Backend
+
+For projects already using SQLAlchemy or SQLModel with PostgreSQL or MySQL,
+you can reuse your existing database connection instead of SQLite.
+```bash
+pip install fastapi-crons[sqlalchemy]
+# or
+pip install fastapi-crons[sqlmodel]
+```
+```python
+from sqlalchemy.ext.asyncio import create_async_engine
+from fastapi_crons import Crons
+from fastapi_crons.state.sqlalchemy import SQLAlchemyStateBackend
+
+engine  = create_async_engine("postgresql+asyncpg://user:pass@host/db")
+backend = SQLAlchemyStateBackend(engine)
+crons   = Crons(app, state_backend=backend)
+```
+
+Works with sync engines too:
+```python
+from sqlalchemy import create_engine
+engine  = create_engine("postgresql://user:pass@host/db")
+backend = SQLAlchemyStateBackend(engine)
+```
+
+### Alembic Integration
+```python
+# env.py
+from fastapi_crons.state.sqlalchemy import cron_metadata
+target_metadata = [Base.metadata, cron_metadata]
+```
+
+---
+
+## 🔒 SQLAlchemy Lock Backend
+```bash
+pip install fastapi-crons[sqlalchemy]
+```
+```python
+from fastapi_crons.locking.sqlalchemy import SQLAlchemyLockBackend
+from fastapi_crons.locking import DistributedLockManager
+from fastapi_crons import CronConfig
+
+engine  = create_async_engine("postgresql+asyncpg://...")
+backend = SQLAlchemyLockBackend(engine)
+manager = DistributedLockManager(backend, CronConfig())
+crons   = Crons(app, lock_manager=manager)
+```
+
+For PostgreSQL, advisory locks are available as a lighter alternative (no table required):
+```python
+from fastapi_crons.locking.sqlalchemy import PostgreSQLAdvisoryLockBackend
+
+backend = PostgreSQLAdvisoryLockBackend(engine)
+```
+
 ### Table:
 
 ```sql

--- a/examples/advanced_hooks/app.py
+++ b/examples/advanced_hooks/app.py
@@ -38,8 +38,7 @@ from fastapi_crons import (
 # =============================================================================
 
 logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
 logger = logging.getLogger(__name__)
 
@@ -60,6 +59,7 @@ app.include_router(get_cron_router(), prefix="/crons", tags=["Cron Jobs"])
 # =============================================================================
 # CUSTOM HOOKS
 # =============================================================================
+
 
 def custom_before_hook(job_name: str, context: dict[str, Any]):
     """
@@ -143,15 +143,13 @@ def performance_tracking_hook(job_name: str, context: dict[str, Any]):
     threshold = 5.0  # 5 seconds
 
     if duration > threshold:
-        logger.warning(
-            f"⚠️ SLOW JOB: '{job_name}' took {duration:.2f}s "
-            f"(threshold: {threshold}s)"
-        )
+        logger.warning(f"⚠️ SLOW JOB: '{job_name}' took {duration:.2f}s (threshold: {threshold}s)")
 
 
 # =============================================================================
 # CRON JOBS WITH HOOKS
 # =============================================================================
+
 
 # Job with individual hooks attached via method chaining
 @crons.cron("*/2 * * * *", name="job_with_hooks")
@@ -266,6 +264,7 @@ if slow_job:
 # =============================================================================
 # API ENDPOINTS
 # =============================================================================
+
 
 @app.get("/")
 def root():

--- a/examples/basic_usage/app.py
+++ b/examples/basic_usage/app.py
@@ -46,6 +46,7 @@ app.include_router(get_cron_router(), prefix="/crons", tags=["Cron Jobs"])
 # CRON JOBS
 # =============================================================================
 
+
 # Simple sync job running every minute
 # The job name defaults to the function name if not specified
 @crons.cron("* * * * *")
@@ -152,6 +153,7 @@ def weekly_backup():
 # =============================================================================
 # API ENDPOINTS
 # =============================================================================
+
 
 @app.get("/")
 def root():

--- a/examples/distributed_locking/app.py
+++ b/examples/distributed_locking/app.py
@@ -42,6 +42,7 @@ from fastapi_crons.locking import (
 # Try to import redis
 try:
     import redis.asyncio as redis
+
     REDIS_AVAILABLE = True
 except ImportError:
     REDIS_AVAILABLE = False
@@ -53,8 +54,7 @@ except ImportError:
 # =============================================================================
 
 logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
 logger = logging.getLogger(__name__)
 
@@ -64,10 +64,7 @@ logger = logging.getLogger(__name__)
 # =============================================================================
 
 # Get unique instance ID (defaults to hostname + port for uniqueness)
-INSTANCE_ID = os.getenv(
-    "CRON_INSTANCE_ID",
-    f"{socket.gethostname()}-{os.getpid()}"
-)
+INSTANCE_ID = os.getenv("CRON_INSTANCE_ID", f"{socket.gethostname()}-{os.getpid()}")
 
 # Redis configuration
 REDIS_URL = os.getenv("CRON_REDIS_URL", "redis://localhost:6379/0")
@@ -150,6 +147,7 @@ app.include_router(get_cron_router(), prefix="/crons", tags=["Cron Jobs"])
 # CRON JOBS (Only one instance runs each job)
 # =============================================================================
 
+
 @crons.cron("*/1 * * * *", name="exclusive_job", tags=["distributed"])
 async def exclusive_job():
     """
@@ -192,7 +190,7 @@ async def long_running_job():
 
     # Simulate long work
     for i in range(6):
-        logger.info(f"   Progress: {i+1}/6")
+        logger.info(f"   Progress: {i + 1}/6")
         await asyncio.sleep(10)
 
     logger.info(f"✅ Long-running job completed on {INSTANCE_ID}")
@@ -228,6 +226,7 @@ def hourly_synchronized_job():
 # =============================================================================
 # API ENDPOINTS
 # =============================================================================
+
 
 @app.get("/")
 def root():
@@ -268,7 +267,9 @@ async def get_lock_status(job_name: str):
         "job_name": job_name,
         "lock_key": lock_key,
         "is_locked": is_locked,
-        "message": "Job is currently running on another instance" if is_locked else "Job is available",
+        "message": "Job is currently running on another instance"
+        if is_locked
+        else "Job is available",
     }
 
 

--- a/examples/full_featured/app.py
+++ b/examples/full_featured/app.py
@@ -57,8 +57,7 @@ from fastapi_crons import (
 # =============================================================================
 
 logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
 logger = logging.getLogger(__name__)
 
@@ -152,6 +151,7 @@ if ENABLE_OTEL and is_otel_available():
 # CUSTOM HOOKS
 # =============================================================================
 
+
 def business_metric_hook(job_name: str, context: dict[str, Any]):
     """
     Custom hook for recording business metrics.
@@ -214,6 +214,7 @@ if otel_hooks:
 # =============================================================================
 # CRON JOBS - Various Patterns
 # =============================================================================
+
 
 # -----------------------------------------------------------------------------
 # 1. Simple job with minimal configuration
@@ -345,6 +346,7 @@ async def generate_daily_report():
 class DatabaseError(Exception):
     pass
 
+
 class NetworkError(Exception):
     pass
 
@@ -415,6 +417,7 @@ async def send_pending_webhooks():
 # API ENDPOINTS
 # =============================================================================
 
+
 @app.get("/")
 def root():
     """API overview with all endpoints."""
@@ -445,8 +448,7 @@ def get_metrics():
         "collector": "MetricsCollector",
         "all_metrics": metrics_collector.get_metrics(),
         "per_job": {
-            job.name: metrics_collector.get_job_metrics(job.name)
-            for job in crons.get_jobs()
+            job.name: metrics_collector.get_job_metrics(job.name) for job in crons.get_jobs()
         },
     }
 

--- a/examples/health_monitoring/app.py
+++ b/examples/health_monitoring/app.py
@@ -37,8 +37,7 @@ from fastapi_crons import (
 # =============================================================================
 
 logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
 logger = logging.getLogger(__name__)
 
@@ -63,6 +62,7 @@ app.include_router(get_cron_router(), prefix="/crons", tags=["Cron Jobs"])
 # CUSTOM HEALTH TRACKING
 # =============================================================================
 
+
 class HealthTracker:
     """
     Custom health tracker for detailed monitoring.
@@ -77,19 +77,18 @@ class HealthTracker:
 
     def record_execution(self, job_name: str, success: bool, duration: float):
         """Record a job execution."""
-        self.job_history.append({
-            "job_name": job_name,
-            "success": success,
-            "duration": duration,
-            "timestamp": datetime.now(timezone.utc),
-        })
+        self.job_history.append(
+            {
+                "job_name": job_name,
+                "success": success,
+                "duration": duration,
+                "timestamp": datetime.now(timezone.utc),
+            }
+        )
 
         # Clean old entries
         cutoff = datetime.now(timezone.utc) - timedelta(minutes=self.window_minutes)
-        self.job_history = [
-            e for e in self.job_history
-            if e["timestamp"] > cutoff
-        ]
+        self.job_history = [e for e in self.job_history if e["timestamp"] > cutoff]
 
     def get_stats(self) -> dict:
         """Get health statistics."""
@@ -126,6 +125,7 @@ health_tracker = HealthTracker()
 # HEALTH TRACKING HOOKS
 # =============================================================================
 
+
 def track_success(job_name: str, context: dict):
     """Hook to track successful job execution."""
     health_tracker.record_execution(
@@ -147,6 +147,7 @@ def track_failure(job_name: str, context: dict):
 # =============================================================================
 # CRON JOBS
 # =============================================================================
+
 
 @crons.cron("*/1 * * * *", name="healthy_job", tags=["monitored"])
 async def healthy_job():
@@ -205,6 +206,7 @@ for job in crons.get_jobs():
 # HEALTH CHECK ENDPOINTS
 # =============================================================================
 
+
 @app.get("/")
 def root():
     """Root endpoint with health endpoint links."""
@@ -233,12 +235,14 @@ async def detailed_health():
     job_statuses = []
     for job in jobs:
         status = await backend.get_job_status(job.name)
-        job_statuses.append({
-            "name": job.name,
-            "tags": job.tags,
-            "next_run": job.next_run.isoformat(),
-            "status": status.get("status") if status else "unknown",
-        })
+        job_statuses.append(
+            {
+                "name": job.name,
+                "tags": job.tags,
+                "next_run": job.next_run.isoformat(),
+                "status": status.get("status") if status else "unknown",
+            }
+        )
 
     stats = health_tracker.get_stats()
 
@@ -344,27 +348,27 @@ async def prometheus_metrics():
     lines = [
         "# HELP cron_uptime_seconds Uptime in seconds",
         "# TYPE cron_uptime_seconds gauge",
-        f'cron_uptime_seconds {health_tracker.get_uptime():.2f}',
+        f"cron_uptime_seconds {health_tracker.get_uptime():.2f}",
         "",
         "# HELP cron_jobs_total Total number of registered jobs",
         "# TYPE cron_jobs_total gauge",
-        f'cron_jobs_total {len(jobs)}',
+        f"cron_jobs_total {len(jobs)}",
         "",
         "# HELP cron_executions_total Total job executions in last hour",
         "# TYPE cron_executions_total counter",
-        f'cron_executions_total {stats["total_executions"]}',
+        f"cron_executions_total {stats['total_executions']}",
         "",
         "# HELP cron_success_rate Job success rate",
         "# TYPE cron_success_rate gauge",
-        f'cron_success_rate {stats["success_rate"]:.4f}',
+        f"cron_success_rate {stats['success_rate']:.4f}",
         "",
         "# HELP cron_failures_total Job failures in last hour",
         "# TYPE cron_failures_total counter",
-        f'cron_failures_total {stats["failures_last_hour"]}',
+        f"cron_failures_total {stats['failures_last_hour']}",
         "",
         "# HELP cron_avg_duration_seconds Average job duration",
         "# TYPE cron_avg_duration_seconds gauge",
-        f'cron_avg_duration_seconds {stats["avg_duration"]:.4f}',
+        f"cron_avg_duration_seconds {stats['avg_duration']:.4f}",
     ]
 
     return Response(content="\n".join(lines), media_type="text/plain")

--- a/examples/opentelemetry_integration/app.py
+++ b/examples/opentelemetry_integration/app.py
@@ -61,16 +61,19 @@ if is_otel_available():
             OTLPMetricExporter,  # noqa: F401
         )
         from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+
         OTLP_AVAILABLE = True
     except ImportError:
         OTLP_AVAILABLE = False
 
     # Create resource with service name
-    resource = Resource.create({
-        "service.name": "fastapi-crons-example",
-        "service.version": "1.0.0",
-        "deployment.environment": "development",
-    })
+    resource = Resource.create(
+        {
+            "service.name": "fastapi-crons-example",
+            "service.version": "1.0.0",
+            "deployment.environment": "development",
+        }
+    )
 
     # Setup tracing
     tracer_provider = TracerProvider(resource=resource)
@@ -102,9 +105,7 @@ if is_otel_available():
     logging.info("✅ OpenTelemetry configured successfully")
 else:
     OTEL_CONFIGURED = False
-    logging.warning(
-        "⚠️ OpenTelemetry not available. Install with: pip install fastapi-crons[otel]"
-    )
+    logging.warning("⚠️ OpenTelemetry not available. Install with: pip install fastapi-crons[otel]")
 
 
 # =============================================================================
@@ -112,8 +113,7 @@ else:
 # =============================================================================
 
 logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
 logger = logging.getLogger(__name__)
 
@@ -139,9 +139,9 @@ if OTEL_CONFIGURED:
     # Create OpenTelemetry hooks
     otel_hooks = OpenTelemetryHooks(
         service_name="fastapi-crons-example",
-        tracer_name="cron.jobs",        # Custom tracer name
-        meter_name="cron.metrics",       # Custom meter name
-        record_metrics=True,             # Enable metrics recording
+        tracer_name="cron.jobs",  # Custom tracer name
+        meter_name="cron.metrics",  # Custom meter name
+        record_metrics=True,  # Enable metrics recording
     )
 
     # Add hooks to all jobs globally
@@ -159,6 +159,7 @@ if OTEL_CONFIGURED:
 # =============================================================================
 # CRON JOBS
 # =============================================================================
+
 
 @crons.cron("*/1 * * * *", name="traced_job", tags=["traced", "demo"])
 async def traced_job():
@@ -203,11 +204,7 @@ async def flaky_job():
 
 
 @crons.cron(
-    "*/3 * * * *",
-    name="slow_traced_job",
-    max_retries=2,
-    timeout=10.0,
-    tags=["traced", "slow"]
+    "*/3 * * * *", name="slow_traced_job", max_retries=2, timeout=10.0, tags=["traced", "slow"]
 )
 async def slow_traced_job():
     """
@@ -270,6 +267,7 @@ if OTEL_CONFIGURED:
 # =============================================================================
 # API ENDPOINTS
 # =============================================================================
+
 
 @app.get("/")
 def root():

--- a/examples/retry_and_timeout/app.py
+++ b/examples/retry_and_timeout/app.py
@@ -36,8 +36,7 @@ from fastapi_crons import (
 # =============================================================================
 
 logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
 logger = logging.getLogger(__name__)
 
@@ -59,6 +58,7 @@ app.include_router(get_cron_router(), prefix="/crons", tags=["Cron Jobs"])
 # CUSTOM EXCEPTIONS for retry filtering
 # =============================================================================
 
+
 class TransientError(Exception):
     """A transient error that can be retried."""
 
@@ -79,6 +79,7 @@ class DatabaseError(Exception):
 # RETRY CALLBACK for monitoring
 # =============================================================================
 
+
 def on_retry_callback(attempt: int, exception: Exception, delay: float):
     """
     Callback function called on each retry attempt.
@@ -98,13 +99,14 @@ def on_retry_callback(attempt: int, exception: Exception, delay: float):
 # CRON JOBS WITH RETRY
 # =============================================================================
 
+
 # Job with retry using cron decorator parameters
 @crons.cron(
     "*/2 * * * *",
     name="job_with_retry",
-    max_retries=3,           # Retry up to 3 times
-    retry_delay=2.0,         # Initial delay of 2 seconds
-    tags=["retry"]
+    max_retries=3,  # Retry up to 3 times
+    retry_delay=2.0,  # Initial delay of 2 seconds
+    tags=["retry"],
 )
 async def job_with_retry():
     """
@@ -129,7 +131,7 @@ async def job_with_retry():
     max_retries=3,
     retry_delay=1.0,
     retry_on=(NetworkError, TransientError),  # Only retry these
-    tags=["retry", "filtered"]
+    tags=["retry", "filtered"],
 )
 async def job_with_filtered_retry():
     """
@@ -157,12 +159,13 @@ async def job_with_filtered_retry():
 # CRON JOBS WITH TIMEOUT
 # =============================================================================
 
+
 # Job with timeout configuration
 @crons.cron(
     "*/2 * * * *",
     name="job_with_timeout",
     timeout=5.0,  # 5 second timeout
-    tags=["timeout"]
+    tags=["timeout"],
 )
 async def job_with_timeout():
     """
@@ -190,7 +193,7 @@ async def job_with_timeout():
     max_retries=2,
     retry_delay=1.0,
     timeout=3.0,  # 3 second timeout
-    tags=["retry", "timeout"]
+    tags=["retry", "timeout"],
 )
 async def job_with_retry_and_timeout():
     """
@@ -223,13 +226,14 @@ async def job_with_retry_and_timeout():
 # USING @retry_on_failure DECORATOR STANDALONE
 # =============================================================================
 
+
 # The retry_on_failure decorator can be used standalone for any function
 @retry_on_failure(
     max_retries=3,
     retry_delay=0.5,
     backoff_multiplier=2.0,  # Double delay each retry
-    max_delay=10.0,          # Cap delay at 10 seconds
-    jitter=True,             # Add random jitter to prevent thundering herd
+    max_delay=10.0,  # Cap delay at 10 seconds
+    jitter=True,  # Add random jitter to prevent thundering herd
     on_retry=on_retry_callback,
 )
 async def fetch_data_with_retry(url: str) -> dict:
@@ -266,6 +270,7 @@ async def fetch_job():
 # USING execute_with_retry() DYNAMICALLY
 # =============================================================================
 
+
 @crons.cron("*/3 * * * *", name="dynamic_retry_job", tags=["dynamic"])
 async def dynamic_retry_job():
     """
@@ -292,9 +297,7 @@ async def dynamic_retry_job():
 
     try:
         result = await execute_with_retry(
-            unstable_operation,
-            retry_config,
-            job_name="dynamic_operation"
+            unstable_operation, retry_config, job_name="dynamic_operation"
         )
         logger.info(f"Dynamic retry job succeeded: {result}")
         return result
@@ -306,6 +309,7 @@ async def dynamic_retry_job():
 # =============================================================================
 # ERROR HANDLING HOOK for timeout
 # =============================================================================
+
 
 def handle_timeout_error(job_name: str, context: dict):
     """Hook to handle timeout errors specifically."""
@@ -325,6 +329,7 @@ if timeout_job:
 # =============================================================================
 # API ENDPOINTS
 # =============================================================================
+
 
 @app.get("/")
 def root():

--- a/fastapi_crons/__init__.py
+++ b/fastapi_crons/__init__.py
@@ -51,4 +51,3 @@ __all__ = [
     "retry_on_failure",
     "webhook_notification",
 ]
-

--- a/fastapi_crons/cli.py
+++ b/fastapi_crons/cli.py
@@ -14,6 +14,7 @@ from .state import RedisStateBackend, SQLiteStateBackend
 
 try:
     import redis.asyncio as redis
+
     REDIS_AVAILABLE = True
 except ImportError:
     REDIS_AVAILABLE = False
@@ -27,6 +28,7 @@ config = CronConfig()
 state_backend = None
 lock_manager = None
 
+
 def get_state_backend():
     """Get the appropriate state backend based on configuration."""
     global state_backend
@@ -36,19 +38,26 @@ def get_state_backend():
                 console.print("[red]Redis not available. Install with: pip install redis[/red]")
                 return
             try:
-                redis_client = redis.from_url(config.redis_url) if config.redis_url else redis.Redis(
-                    host=config.redis_host,
-                    port=config.redis_port,
-                    db=config.redis_db,
-                    password=config.redis_password
+                redis_client = (
+                    redis.from_url(config.redis_url)
+                    if config.redis_url
+                    else redis.Redis(
+                        host=config.redis_host,
+                        port=config.redis_port,
+                        db=config.redis_db,
+                        password=config.redis_password,
+                    )
                 )
                 state_backend = RedisStateBackend(redis_client)
             except Exception as e:
-                console.print(f"[yellow]Error connecting to Redis: {e}, falling back to SQLite[/yellow]")
+                console.print(
+                    f"[yellow]Error connecting to Redis: {e}, falling back to SQLite[/yellow]"
+                )
                 state_backend = SQLiteStateBackend(config.sqlite_db_path)
         else:
             state_backend = SQLiteStateBackend(config.sqlite_db_path)
     return state_backend
+
 
 def get_lock_manager():
     """Get the appropriate lock manager based on configuration."""
@@ -59,15 +68,21 @@ def get_lock_manager():
                 console.print("[red]Redis not available. Install with: pip install redis[/red]")
                 return
             try:
-                redis_client = redis.from_url(config.redis_url) if config.redis_url else redis.Redis(
-                    host=config.redis_host,
-                    port=config.redis_port,
-                    db=config.redis_db,
-                    password=config.redis_password
+                redis_client = (
+                    redis.from_url(config.redis_url)
+                    if config.redis_url
+                    else redis.Redis(
+                        host=config.redis_host,
+                        port=config.redis_port,
+                        db=config.redis_db,
+                        password=config.redis_password,
+                    )
                 )
                 lock_backend = RedisLockBackend(redis_client)
             except Exception as e:
-                console.print(f"[yellow]Error connecting to Redis: {e}, using local locking: {e}[/yellow]")
+                console.print(
+                    f"[yellow]Error connecting to Redis: {e}, using local locking: {e}[/yellow]"
+                )
                 lock_backend = LocalLockBackend()
         else:
             lock_backend = LocalLockBackend()
@@ -75,10 +90,11 @@ def get_lock_manager():
         lock_manager = DistributedLockManager(lock_backend, config)
     return lock_manager
 
+
 @cli.command()
 def config_set(
     key: str = typer.Argument(..., help="Configuration key"),
-    value: str = typer.Argument(..., help="Configuration value")
+    value: str = typer.Argument(..., help="Configuration value"),
 ):
     """Set configuration values."""
     global config
@@ -87,7 +103,7 @@ def config_set(
         # Convert value to appropriate type
         current_value = getattr(config, key)
         if isinstance(current_value, bool):
-            value = value.lower() in ('true', '1', 'yes', 'on')
+            value = value.lower() in ("true", "1", "yes", "on")
         elif isinstance(current_value, int):
             value = int(value)
 
@@ -96,6 +112,7 @@ def config_set(
     else:
         console.print(f"[red]Unknown configuration key: {key}[/red]")
         console.print("Available keys:", list(config.__dict__.keys()))
+
 
 @cli.command()
 def config_show():
@@ -109,16 +126,16 @@ def config_show():
 
     console.print(table)
 
+
 @cli.command()
 def list_jobs():
     """List all registered jobs and their status."""
+
     async def run():
         backend = get_state_backend()
 
         with Progress(
-            SpinnerColumn(),
-            TextColumn("[progress.description]{task.description}"),
-            console=console
+            SpinnerColumn(), TextColumn("[progress.description]{task.description}"), console=console
         ) as progress:
             task = progress.add_task("Loading jobs...", total=None)
 
@@ -154,6 +171,7 @@ def list_jobs():
 
     asyncio.run(run())
 
+
 async def execute_hook(hook, job_name: str, context: dict):
     """Execute a hook function, handling both sync and async hooks."""
     try:
@@ -164,12 +182,14 @@ async def execute_hook(hook, job_name: str, context: dict):
     except Exception as e:
         console.print(f"[red][Hook Error][{job_name}] {e}[/red]")
 
+
 @cli.command()
 def run_job(
     name: str = typer.Argument(..., help="Job name to run"),
-    force: bool = typer.Option(False, "--force", "-f", help="Force run even if locked")
+    force: bool = typer.Option(False, "--force", "-f", help="Force run even if locked"),
 ):
     """Manually run a specific job."""
+
     async def run():
         from .scheduler import Crons
 
@@ -194,14 +214,14 @@ def run_job(
 
         # Check if job is locked
         if not force and await lock_mgr.is_locked(f"job:{name}"):
-            console.print(f"[yellow]Job '{name}' is currently locked (running on another instance)[/yellow]")
+            console.print(
+                f"[yellow]Job '{name}' is currently locked (running on another instance)[/yellow]"
+            )
             console.print("Use --force to override (not recommended)")
             return
 
         with Progress(
-            SpinnerColumn(),
-            TextColumn("[progress.description]{task.description}"),
-            console=console
+            SpinnerColumn(), TextColumn("[progress.description]{task.description}"), console=console
         ) as progress:
             task = progress.add_task(f"Running job '{name}'...", total=None)
 
@@ -246,13 +266,15 @@ def run_job(
                     await backend.set_job_status(name, "completed", config.instance_id)
 
                     # Update context with execution details
-                    context.update({
-                        "success": True,
-                        "start_time": start_time.isoformat(),
-                        "end_time": end_time.isoformat(),
-                        "duration": duration,
-                        "result": result
-                    })
+                    context.update(
+                        {
+                            "success": True,
+                            "start_time": start_time.isoformat(),
+                            "end_time": end_time.isoformat(),
+                            "duration": duration,
+                            "result": result,
+                        }
+                    )
 
                     # Execute after_run hooks
                     for hook in target_job.after_run_hooks:
@@ -260,12 +282,13 @@ def run_job(
 
                     # Log execution
                     await backend.log_job_execution(
-                        name, config.instance_id, "completed",
-                        start_time, end_time, duration
+                        name, config.instance_id, "completed", start_time, end_time, duration
                     )
 
                     progress.remove_task(task)
-                    console.print(f"[green]✓ Job '{name}' completed successfully in {duration:.2f}s[/green]")
+                    console.print(
+                        f"[green]✓ Job '{name}' completed successfully in {duration:.2f}s[/green]"
+                    )
 
                 except Exception as e:
                     end_time = datetime.now(timezone.utc)
@@ -275,13 +298,15 @@ def run_job(
                     await backend.set_job_status(name, "failed", config.instance_id)
 
                     # Update context with error details
-                    context.update({
-                        "success": False,
-                        "start_time": start_time.isoformat(),
-                        "end_time": end_time.isoformat(),
-                        "duration": duration,
-                        "error": error_msg
-                    })
+                    context.update(
+                        {
+                            "success": False,
+                            "start_time": start_time.isoformat(),
+                            "end_time": end_time.isoformat(),
+                            "duration": duration,
+                            "error": error_msg,
+                        }
+                    )
 
                     # Execute on_error hooks
                     for hook in target_job.on_error_hooks:
@@ -289,12 +314,19 @@ def run_job(
 
                     # Log execution
                     await backend.log_job_execution(
-                        name, config.instance_id, "failed",
-                        start_time, end_time, duration, error_msg
+                        name,
+                        config.instance_id,
+                        "failed",
+                        start_time,
+                        end_time,
+                        duration,
+                        error_msg,
                     )
 
                     progress.remove_task(task)
-                    console.print(f"[red]✗ Job '{name}' failed after {duration:.2f}s: {error_msg}[/red]")
+                    console.print(
+                        f"[red]✗ Job '{name}' failed after {duration:.2f}s: {error_msg}[/red]"
+                    )
 
             finally:
                 # Release lock
@@ -303,9 +335,11 @@ def run_job(
 
     asyncio.run(run())
 
+
 @cli.command()
 def status():
     """Show overall system status."""
+
     async def run():
         backend = get_state_backend()
         _ = get_lock_manager()  # Initialize lock manager for status display
@@ -314,8 +348,8 @@ def status():
         system_info = f"""
 [bold]Instance ID:[/bold] {config.instance_id}
 [bold]Backend:[/bold] {type(backend).__name__}
-[bold]Locking:[/bold] {'Distributed' if config.enable_distributed_locking else 'Local'}
-[bold]Redis URL:[/bold] {config.redis_url or 'Not configured'}
+[bold]Locking:[/bold] {"Distributed" if config.enable_distributed_locking else "Local"}
+[bold]Redis URL:[/bold] {config.redis_url or "Not configured"}
         """
 
         console.print(Panel(system_info.strip(), title="System Status", border_style="blue"))
@@ -329,9 +363,9 @@ def status():
             for job_name, _ in jobs:
                 status_info = await backend.get_job_status(job_name)
                 if status_info:
-                    if status_info['status'] == 'running':
+                    if status_info["status"] == "running":
                         running_jobs += 1
-                    elif status_info['status'] == 'failed':
+                    elif status_info["status"] == "failed":
                         failed_jobs += 1
 
             stats = f"""
@@ -347,10 +381,11 @@ def status():
 
     asyncio.run(run())
 
+
 @cli.command()
 def start_scheduler(
     daemon: bool = typer.Option(False, "--daemon", "-d", help="Run as daemon"),
-    log_level: str = typer.Option("INFO", "--log-level", help="Log level")
+    log_level: str = typer.Option("INFO", "--log-level", help="Log level"),
 ):
     """Start the cron scheduler."""
     import logging
@@ -358,7 +393,7 @@ def start_scheduler(
     # Configure logging
     logging.basicConfig(
         level=getattr(logging, log_level.upper()),
-        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     )
 
     async def run():
@@ -372,7 +407,9 @@ def start_scheduler(
         crons = Crons(state_backend=backend, lock_manager=lock_mgr, config=config)
 
         if not crons.get_jobs():
-            console.print("[yellow]No jobs registered. Make sure to import your job modules.[/yellow]")
+            console.print(
+                "[yellow]No jobs registered. Make sure to import your job modules.[/yellow]"
+            )
         else:
             console.print(f"[blue]Loaded {len(crons.get_jobs())} jobs[/blue]")
 
@@ -401,13 +438,15 @@ def start_scheduler(
     except KeyboardInterrupt:
         console.print("\n[yellow]Interrupted[/yellow]")
 
+
 @cli.command()
 def logs(
     job_name: str | None = typer.Option(None, "--job", "-j", help="Filter by job name"),
     limit: int = typer.Option(50, "--limit", "-l", help="Number of log entries to show"),
-    follow: bool = typer.Option(False, "--follow", "-f", help="Follow log output")
+    follow: bool = typer.Option(False, "--follow", "-f", help="Follow log output"),
 ):
     """Show job execution logs."""
+
     async def run():
         _ = get_state_backend()  # Ensure backend is available
 
@@ -416,6 +455,7 @@ def logs(
         console.print("[yellow]Log viewing feature coming soon[/yellow]")
 
     asyncio.run(run())
+
 
 if __name__ == "__main__":
     cli()

--- a/fastapi_crons/config.py
+++ b/fastapi_crons/config.py
@@ -20,21 +20,28 @@ class CronConfig:
         self.redis_password: str | None = os.getenv("CRON_REDIS_PASSWORD")
 
         # Distributed locking configuration
-        self.enable_distributed_locking: bool = os.getenv("CRON_ENABLE_DISTRIBUTED_LOCKING", "false").lower() in ("true", "1", "yes")
+        self.enable_distributed_locking: bool = os.getenv(
+            "CRON_ENABLE_DISTRIBUTED_LOCKING", "false"
+        ).lower() in ("true", "1", "yes")
         self.lock_ttl: int = int(os.getenv("CRON_LOCK_TTL", "300"))  # 5 minutes default
 
         # Logging configuration
         self.log_level: str = os.getenv("CRON_LOG_LEVEL", "INFO")
-        self.enable_job_logging: bool = os.getenv("CRON_ENABLE_JOB_LOGGING", "true").lower() in ("true", "1", "yes")
+        self.enable_job_logging: bool = os.getenv("CRON_ENABLE_JOB_LOGGING", "true").lower() in (
+            "true",
+            "1",
+            "yes",
+        )
 
         # Retry configuration - defaults for jobs that don't specify their own
         self.default_max_retries: int = int(os.getenv("CRON_DEFAULT_MAX_RETRIES", "0"))
         self.default_retry_delay: float = float(os.getenv("CRON_DEFAULT_RETRY_DELAY", "1.0"))
-        self.retry_backoff_multiplier: float = float(os.getenv("CRON_RETRY_BACKOFF_MULTIPLIER", "2.0"))
+        self.retry_backoff_multiplier: float = float(
+            os.getenv("CRON_RETRY_BACKOFF_MULTIPLIER", "2.0")
+        )
         self.max_retry_delay: float = float(os.getenv("CRON_MAX_RETRY_DELAY", "300.0"))
 
         # Timeout configuration - default for jobs that don't specify their own
         # None means no timeout (jobs can run indefinitely)
         timeout_env = os.getenv("CRON_DEFAULT_JOB_TIMEOUT")
         self.default_job_timeout: float | None = float(timeout_env) if timeout_env else None
-

--- a/fastapi_crons/endpoints.py
+++ b/fastapi_crons/endpoints.py
@@ -44,13 +44,13 @@ def get_cron_router():
                 "hooks": {
                     "before_run": len(job.before_run_hooks),
                     "after_run": len(job.after_run_hooks),
-                    "on_error": len(job.on_error_hooks)
+                    "on_error": len(job.on_error_hooks),
                 },
                 "config": {
                     "max_retries": job.max_retries,
                     "retry_delay": job.retry_delay,
                     "timeout": job.timeout,
-                }
+                },
             }
 
             if status_info:
@@ -87,11 +87,11 @@ def get_cron_router():
             for job in jobs:
                 status_info = await backend.get_job_status(job.name)
                 if status_info:
-                    if status_info['status'] == 'running':
+                    if status_info["status"] == "running":
                         running_count += 1
-                    elif status_info['status'] == 'failed':
+                    elif status_info["status"] == "failed":
                         failed_count += 1
-                    elif status_info['status'] == 'completed':
+                    elif status_info["status"] == "completed":
                         completed_count += 1
         except Exception:
             backend_connected = False
@@ -130,7 +130,7 @@ def get_cron_router():
                 "distributed_locking": config.enable_distributed_locking,
                 "default_timeout": config.default_job_timeout,
                 "default_max_retries": config.default_max_retries,
-            }
+            },
         }
 
     @router.get("/system/status")
@@ -147,11 +147,11 @@ def get_cron_router():
         for job in jobs:
             status_info = await backend.get_job_status(job.name)
             if status_info:
-                if status_info['status'] == 'running':
+                if status_info["status"] == "running":
                     running_count += 1
-                elif status_info['status'] == 'failed':
+                elif status_info["status"] == "failed":
                     failed_count += 1
-                elif status_info['status'] == 'completed':
+                elif status_info["status"] == "completed":
                     completed_count += 1
 
         return {
@@ -162,7 +162,7 @@ def get_cron_router():
             "completed_jobs": completed_count,
             "backend_type": type(backend).__name__,
             "distributed_locking": config.enable_distributed_locking,
-            "redis_configured": bool(config.redis_url or config.redis_host != "localhost")
+            "redis_configured": bool(config.redis_url or config.redis_host != "localhost"),
         }
 
     @router.get("/")
@@ -191,8 +191,8 @@ def get_cron_router():
             "hooks": {
                 "before_run": len(job.before_run_hooks),
                 "after_run": len(job.after_run_hooks),
-                "on_error": len(job.on_error_hooks)
-            }
+                "on_error": len(job.on_error_hooks),
+            },
         }
 
     @router.get("/{job_name}/status")
@@ -231,16 +231,14 @@ def get_cron_router():
         lock_key = f"job:{job_name}"
         if not force and await crons.lock_manager.is_locked(lock_key):
             raise HTTPException(
-                status_code=409,
-                detail=f"Job '{job_name}' is currently running on another instance"
+                status_code=409, detail=f"Job '{job_name}' is currently running on another instance"
             )
 
         # Try to acquire lock
         lock_id = await crons.lock_manager.acquire_lock(lock_key)
         if not lock_id and not force:
             raise HTTPException(
-                status_code=409,
-                detail=f"Failed to acquire lock for job '{job_name}'"
+                status_code=409, detail=f"Failed to acquire lock for job '{job_name}'"
             )
 
         try:
@@ -277,13 +275,15 @@ def get_cron_router():
                 await crons.state_backend.set_job_status(job_name, "completed", config.instance_id)
 
                 # Update context with execution details
-                context.update({
-                    "success": True,
-                    "start_time": start_time.isoformat(),
-                    "end_time": end_time.isoformat(),
-                    "duration": duration,
-                    "result": result
-                })
+                context.update(
+                    {
+                        "success": True,
+                        "start_time": start_time.isoformat(),
+                        "end_time": end_time.isoformat(),
+                        "duration": duration,
+                        "result": result,
+                    }
+                )
 
                 # Execute after_run hooks
                 for hook in job.after_run_hooks:
@@ -291,15 +291,14 @@ def get_cron_router():
 
                 # Log execution
                 await crons.state_backend.log_job_execution(
-                    job_name, config.instance_id, "completed",
-                    start_time, end_time, duration
+                    job_name, config.instance_id, "completed", start_time, end_time, duration
                 )
 
                 return {
                     "status": "success",
                     "message": f"Job '{job_name}' executed successfully",
                     "execution_time": duration,
-                    "instance_id": config.instance_id
+                    "instance_id": config.instance_id,
                 }
 
             except Exception as e:
@@ -310,13 +309,15 @@ def get_cron_router():
                 await crons.state_backend.set_job_status(job_name, "failed", config.instance_id)
 
                 # Update context with error details
-                context.update({
-                    "success": False,
-                    "start_time": start_time.isoformat(),
-                    "end_time": end_time.isoformat(),
-                    "duration": duration,
-                    "error": error_msg
-                })
+                context.update(
+                    {
+                        "success": False,
+                        "start_time": start_time.isoformat(),
+                        "end_time": end_time.isoformat(),
+                        "duration": duration,
+                        "error": error_msg,
+                    }
+                )
 
                 # Execute on_error hooks
                 for hook in job.on_error_hooks:
@@ -324,11 +325,18 @@ def get_cron_router():
 
                 # Log execution
                 await crons.state_backend.log_job_execution(
-                    job_name, config.instance_id, "failed",
-                    start_time, end_time, duration, error_msg
+                    job_name,
+                    config.instance_id,
+                    "failed",
+                    start_time,
+                    end_time,
+                    duration,
+                    error_msg,
                 )
 
-                raise HTTPException(status_code=500, detail=f"Job execution failed: {error_msg}") from e
+                raise HTTPException(
+                    status_code=500, detail=f"Job execution failed: {error_msg}"
+                ) from e
 
         finally:
             # Release lock

--- a/fastapi_crons/hooks.py
+++ b/fastapi_crons/hooks.py
@@ -1,6 +1,7 @@
 """
 Pre-built hooks for common use cases like logging, metrics, alerts, and webhooks.
 """
+
 import logging
 from collections.abc import Callable
 from datetime import datetime, timezone
@@ -11,21 +12,25 @@ import aiohttp
 # Configure logger
 logger = logging.getLogger("fastapi_cron")
 
+
 # Logging hooks
 def log_job_start(job_name: str, context: dict[str, Any]):
     """Log when a job starts."""
     logger.info(f"Job '{job_name}' started at {datetime.now(timezone.utc).isoformat()}")
+
 
 def log_job_success(job_name: str, context: dict[str, Any]):
     """Log when a job completes successfully."""
     duration = context.get("duration", 0)
     logger.info(f"Job '{job_name}' completed successfully in {duration:.2f}s")
 
+
 def log_job_error(job_name: str, context: dict[str, Any]):
     """Log when a job fails."""
     error = context.get("error", "Unknown error")
     duration = context.get("duration", 0)
     logger.error(f"Job '{job_name}' failed after {duration:.2f}s: {error}")
+
 
 # Webhook hooks
 async def webhook_notification(url: str, include_context: bool = True):
@@ -40,12 +45,16 @@ async def webhook_notification(url: str, include_context: bool = True):
         A hook function that can be registered with add_before_run_hook,
         add_after_run_hook, or add_on_error_hook
     """
+
     async def hook(job_name: str, context: dict[str, Any]):
         payload = {
             "job_name": job_name,
             "timestamp": datetime.now(timezone.utc).isoformat(),
-            "event_type": "before_run" if "success" not in context else
-                          "after_run" if context.get("success") else "on_error"
+            "event_type": "before_run"
+            if "success" not in context
+            else "after_run"
+            if context.get("success")
+            else "on_error",
         }
 
         if include_context:
@@ -61,6 +70,7 @@ async def webhook_notification(url: str, include_context: bool = True):
 
     return hook
 
+
 # Metrics hooks
 class MetricsCollector:
     """Simple in-memory metrics collector for cron jobs."""
@@ -70,7 +80,7 @@ class MetricsCollector:
             "job_runs": {},
             "job_durations": {},
             "job_successes": {},
-            "job_failures": {}
+            "job_failures": {},
         }
 
     def record_job_start(self, job_name: str, context: dict[str, Any]):
@@ -108,18 +118,22 @@ class MetricsCollector:
             "successes": self.metrics["job_successes"].get(job_name, 0),
             "failures": self.metrics["job_failures"].get(job_name, 0),
             "durations": self.metrics["job_durations"].get(job_name, []),
-            "avg_duration": sum(self.metrics["job_durations"].get(job_name, [0])) /
-                           max(len(self.metrics["job_durations"].get(job_name, [1])), 1)
+            "avg_duration": sum(self.metrics["job_durations"].get(job_name, [0]))
+            / max(len(self.metrics["job_durations"].get(job_name, [1])), 1),
         }
+
 
 # Create a global metrics collector instance
 metrics_collector = MetricsCollector()
+
 
 # Alert hooks
 class AlertManager:
     """Manager for job alerts."""
 
-    def __init__(self, alert_handlers: list[Callable[[str, str, dict[str, Any]], None]] | None = None):
+    def __init__(
+        self, alert_handlers: list[Callable[[str, str, dict[str, Any]], None]] | None = None
+    ):
         self.alert_handlers = alert_handlers or []
 
     def add_handler(self, handler: Callable[[str, str, dict[str, Any]], None]):
@@ -134,20 +148,25 @@ class AlertManager:
             except Exception as e:
                 logger.error(f"Alert handler failed: {e}")
 
+
 # Create a global alert manager instance
 alert_manager = AlertManager()
+
 
 # Example alert handler for logging
 def log_alert_handler(job_name: str, alert_type: str, context: dict[str, Any]):
     """Log an alert."""
     logger.warning(f"ALERT: {alert_type} for job '{job_name}': {context.get('error', '')}")
 
+
 # Add the log alert handler to the alert manager
 alert_manager.add_handler(log_alert_handler)
+
 
 def alert_on_failure(job_name: str, context: dict[str, Any]):
     """Trigger an alert when a job fails."""
     alert_manager.trigger_alert(job_name, "failure", context)
+
 
 def alert_on_long_duration(threshold_seconds: float):
     """
@@ -159,12 +178,13 @@ def alert_on_long_duration(threshold_seconds: float):
     Returns:
         A hook function that can be registered with add_after_run_hook
     """
+
     def hook(job_name: str, context: dict[str, Any]):
         duration = context.get("duration", 0)
         if duration > threshold_seconds:
             alert_context = {
                 **context,
-                "alert_reason": f"Job took {duration:.2f}s, which exceeds threshold of {threshold_seconds:.2f}s"
+                "alert_reason": f"Job took {duration:.2f}s, which exceeds threshold of {threshold_seconds:.2f}s",
             }
             alert_manager.trigger_alert(job_name, "long_duration", alert_context)
 

--- a/fastapi_crons/job.py
+++ b/fastapi_crons/job.py
@@ -5,9 +5,10 @@ from croniter import croniter
 
 # Type for hook functions - can be sync or async
 HookFunc = (
-    Callable[[str, dict], None] |  # Sync hook
-    Callable[[str, dict], Awaitable[None]]  # Async hook
+    Callable[[str, dict], None]  # Sync hook
+    | Callable[[str, dict], Awaitable[None]]  # Async hook
 )
+
 
 class CronJob:
     def __init__(
@@ -60,6 +61,7 @@ class CronJob:
         self.on_error_hooks.append(hook)
         return self  # For method chaining
 
+
 def cron_job(
     expr: str,
     *,
@@ -90,4 +92,3 @@ def cron_job(
         return func
 
     return wrapper
-

--- a/fastapi_crons/locking/__init__.py
+++ b/fastapi_crons/locking/__init__.py
@@ -5,9 +5,10 @@ import uuid
 from abc import ABC, abstractmethod
 from typing import Any
 
-from .config import CronConfig
+from ..config import CronConfig
 
 logger = logging.getLogger("fastapi_cron.locking")
+
 
 class LockBackend(ABC):
     """Abstract base class for lock backends."""
@@ -27,6 +28,7 @@ class LockBackend(ABC):
     @abstractmethod
     async def renew_lock(self, key: str, lock_id: str, ttl: int) -> bool:
         """Renew a lock's TTL."""
+
 
 class LocalLockBackend(LockBackend):
     """Local in-memory lock backend for single-instance deployments."""
@@ -50,11 +52,7 @@ class LocalLockBackend(LockBackend):
 
             # Acquire new lock
             lock_id = str(uuid.uuid4())
-            self.locks[key] = {
-                "lock_id": lock_id,
-                "expires_at": now + ttl,
-                "acquired_at": now
-            }
+            self.locks[key] = {"lock_id": lock_id, "expires_at": now + ttl, "acquired_at": now}
 
             return lock_id
 
@@ -87,6 +85,7 @@ class LocalLockBackend(LockBackend):
                 self.locks[key]["expires_at"] = time.time() + ttl
                 return True
             return False
+
 
 class RedisLockBackend(LockBackend):
     """Redis-based lock backend for distributed deployments."""
@@ -152,6 +151,7 @@ class RedisLockBackend(LockBackend):
             logger.error(f"Error renewing lock {key}: {e}")
             return False
 
+
 class DistributedLockManager:
     """Manager for distributed locking with automatic renewal."""
 
@@ -214,7 +214,9 @@ class DistributedLockManager:
                     try:
                         success = await self.backend.renew_lock(key, lock_id, self.config.lock_ttl)
                         if not success:
-                            logger.warning(f"Failed to renew lock for {key}, removing from active locks")
+                            logger.warning(
+                                f"Failed to renew lock for {key}, removing from active locks"
+                            )
                             self.active_locks.pop(key, None)
                         else:
                             logger.debug(f"Renewed lock for {key}")

--- a/fastapi_crons/locking/sqlalchemy.py
+++ b/fastapi_crons/locking/sqlalchemy.py
@@ -1,0 +1,353 @@
+"""
+SQLAlchemy lock backends for fastapi-crons.
+
+Two implementations sharing the same LockBackend interface:
+
+- SQLAlchemyLockBackend     : table-based, works with SQLite / PostgreSQL / MySQL
+- PostgreSQLAdvisoryLockBackend : advisory locks, PostgreSQL only, zero table
+
+Install with: pip install fastapi-crons[sqlalchemy]
+
+Usage:
+    from sqlalchemy.ext.asyncio import create_async_engine
+    from fastapi_crons.locking.sqlalchemy import SQLAlchemyLockBackend
+    from fastapi_crons.locking import DistributedLockManager
+    from fastapi_crons import CronConfig
+
+    engine  = create_async_engine("postgresql+asyncpg://...")
+    backend = SQLAlchemyLockBackend(engine)
+    manager = DistributedLockManager(backend, CronConfig())
+
+Alembic integration:
+    from fastapi_crons.locking.sqlalchemy import cron_locks_metadata
+    target_metadata = [Base.metadata, cron_locks_metadata]
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from fastapi_crons.locking import LockBackend
+
+logger = logging.getLogger("fastapi_cron.locking.sqlalchemy")
+
+
+try:
+    from sqlalchemy import MetaData, String, delete, select, update
+    from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+except ImportError as err:
+    raise ImportError(
+        "SQLAlchemy is required for SQLAlchemyLockBackend.\n"
+        "Install with: pip install fastapi-crons[sqlalchemy]"
+    ) from err
+
+
+class _LockBase(DeclarativeBase):
+    pass
+
+
+class _CronLock(_LockBase):
+    """Distributed lock record with explicit TTL."""
+
+    __tablename__ = "cron_locks"
+
+    key: Mapped[str] = mapped_column(String(255), primary_key=True)
+    lock_id: Mapped[str] = mapped_column(String(36), nullable=False)
+    acquired_by: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    acquired_at: Mapped[str] = mapped_column(String(50), nullable=False)
+    expires_at: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+
+
+cron_locks_metadata: MetaData = _LockBase.metadata
+"""
+SQLAlchemy MetaData containing the cron_locks table.
+
+    from fastapi_crons.locking.sqlalchemy import cron_locks_metadata
+    target_metadata = [Base.metadata, cron_locks_metadata]
+"""
+
+
+def _upsert_lock(dialect_name: str, values: dict[str, Any], set_cols: dict[str, Any]) -> Any:
+    if dialect_name in ("mysql", "mariadb"):
+        from sqlalchemy.dialects.mysql import insert as mysql_insert
+
+        return mysql_insert(_CronLock).values(**values).on_duplicate_key_update(**set_cols)
+
+    if dialect_name == "postgresql":
+        from sqlalchemy.dialects.postgresql import insert as insert
+    elif dialect_name == "sqlite":
+        from sqlalchemy.dialects.sqlite import insert as insert  # type: ignore[assignment]
+    else:
+        raise NotImplementedError(
+            f"Unsupported dialect: {dialect_name!r}. Supported: postgresql, sqlite, mysql, mariadb."
+        )
+
+    return (
+        insert(_CronLock)
+        .values(**values)
+        .on_conflict_do_update(index_elements=["key"], set_=set_cols)
+    )
+
+
+class SQLAlchemyLockBackend(LockBackend):
+    """
+    Table-based distributed lock backend for fastapi-crons.
+
+    Uses a cron_locks table with explicit expires_at TTL.
+    Compatible with SQLite, PostgreSQL, and MySQL.
+
+    Expired locks are cleaned up passively on each acquire attempt —
+    no background task required.
+
+    Args:
+        engine       : SQLAlchemy Engine or AsyncEngine.
+        create_tables: Auto-create cron_locks table (default True).
+                       Set to False when using Alembic.
+        instance_id  : Optional identifier stored in acquired_by column.
+    """
+
+    def __init__(
+        self,
+        engine: Any,
+        create_tables: bool = True,
+        instance_id: str | None = None,
+    ) -> None:
+        from sqlalchemy.ext.asyncio import AsyncEngine
+
+        self._is_async: bool = isinstance(engine, AsyncEngine)
+        self._engine = engine
+        self._dialect: str = engine.dialect.name
+        self._create_tables = create_tables
+        self._instance_id = instance_id
+        self._tables_created = False
+        self._init_lock = asyncio.Lock()
+
+    async def _ensure_tables(self) -> None:
+        if not self._create_tables or self._tables_created:
+            return
+        async with self._init_lock:
+            if self._tables_created:
+                return
+            await self._run(None, create_all=True)
+            self._tables_created = True
+
+    async def _run(self, stmt: Any, *, create_all: bool = False) -> Any:
+        if self._is_async:
+            async with self._engine.begin() as conn:
+                if create_all:
+                    await conn.run_sync(_LockBase.metadata.create_all)
+                    return None
+                return await conn.execute(stmt)
+        else:
+
+            def _blocking() -> Any:
+                with self._engine.begin() as _conn:
+                    if create_all:
+                        _LockBase.metadata.create_all(_conn)
+                        return None
+                    return _conn.execute(stmt)
+
+            return await asyncio.to_thread(_blocking)
+
+    async def acquire_lock(self, key: str, ttl: int) -> str | None:
+        """
+        Acquire a lock.
+
+        Passively cleans expired locks on each attempt.
+        Returns a lock_id string if acquired, None if already locked.
+        """
+        await self._ensure_tables()
+        now = datetime.now(timezone.utc)
+        now_iso = now.isoformat()
+
+        await self._run(delete(_CronLock).where(_CronLock.expires_at <= now_iso))
+
+        result = await self._run(
+            select(_CronLock.lock_id, _CronLock.expires_at).where(_CronLock.key == key)
+        )
+        row = result.fetchone()
+        if row:
+            return None
+
+        lock_id = str(uuid.uuid4())
+        expires_at = (now + timedelta(seconds=ttl)).isoformat()
+        values = {
+            "key": key,
+            "lock_id": lock_id,
+            "acquired_by": self._instance_id,
+            "acquired_at": now_iso,
+            "expires_at": expires_at,
+        }
+        set_cols = {k: v for k, v in values.items() if k != "key"}
+
+        try:
+            await self._run(_upsert_lock(self._dialect, values, set_cols))
+            return lock_id
+        except Exception as e:
+            logger.debug("Lock acquisition race for %s: %s", key, e)
+            return None
+
+    async def release_lock(self, key: str, lock_id: str) -> bool:
+        """Release a lock only if we own it (lock_id matches)."""
+        await self._ensure_tables()
+        result = await self._run(
+            delete(_CronLock).where((_CronLock.key == key) & (_CronLock.lock_id == lock_id))
+        )
+        return result.rowcount > 0  # type: ignore
+
+    async def is_locked(self, key: str) -> bool:
+        """Check if a key is currently locked (not expired)."""
+        await self._ensure_tables()
+        now_iso = datetime.now(timezone.utc).isoformat()
+        result = await self._run(
+            select(_CronLock.key).where((_CronLock.key == key) & (_CronLock.expires_at > now_iso))
+        )
+        return result.fetchone() is not None
+
+    async def renew_lock(self, key: str, lock_id: str, ttl: int) -> bool:
+        """Extend the TTL of an owned lock."""
+        await self._ensure_tables()
+        new_expires = (datetime.now(timezone.utc) + timedelta(seconds=ttl)).isoformat()
+        result = await self._run(
+            update(_CronLock)
+            .where((_CronLock.key == key) & (_CronLock.lock_id == lock_id))
+            .values(expires_at=new_expires)
+        )
+        return result.rowcount > 0  # type: ignore
+
+    async def dispose(self) -> None:
+        """Dispose the engine connection pool."""
+        if self._is_async:
+            await self._engine.dispose()
+        else:
+            await asyncio.to_thread(self._engine.dispose)
+
+
+class PostgreSQLAdvisoryLockBackend(LockBackend):
+    """
+    PostgreSQL advisory lock backend for fastapi-crons.
+
+    Uses pg_try_advisory_lock() / pg_advisory_unlock() — no table required.
+    Advisory locks are session-scoped and released automatically on disconnect.
+
+    Lighter than table-based locks but PostgreSQL-only.
+    TTL and renew are no-ops (advisory locks don't expire natively) —
+    the DistributedLockManager renewal loop is harmless but unnecessary.
+
+    Args:
+        engine: AsyncEngine or Engine pointing to a PostgreSQL database.
+    """
+
+    def __init__(self, engine: Any) -> None:
+        from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine
+
+        if not isinstance(engine, AsyncEngine):
+            raise TypeError(
+                "PostgreSQLAdvisoryLockBackend requires an AsyncEngine. "
+                "Use create_async_engine() with asyncpg."
+            )
+        self._engine = engine
+        self._connections: dict[str, tuple[AsyncConnection, str]] = {}
+        self._conn_lock = asyncio.Lock()
+
+    def _key_to_int(self, key: str) -> int:
+        """
+        Convert a string key to a 64-bit integer for pg_advisory_lock.
+
+        Uses hash() truncated to PostgreSQL's bigint range.
+        Collision probability is negligible for typical cron job counts.
+        """
+        return hash(key) & 0x7FFFFFFFFFFFFFFF
+
+    async def acquire_lock(self, key: str, ttl: int) -> str | None:
+        """
+        Try to acquire a PostgreSQL advisory lock.
+
+        Uses pg_try_advisory_lock (non-blocking).
+        TTL is ignored — advisory locks are session-scoped.
+        """
+        lock_key = self._key_to_int(key)
+
+        async with self._conn_lock:
+            if key in self._connections:
+                return None
+
+            conn = await self._engine.connect()
+            from sqlalchemy import text
+
+            result = await conn.execute(
+                text("SELECT pg_try_advisory_lock(:key)"), {"key": lock_key}
+            )
+            acquired = result.scalar()
+
+            if acquired:
+                lock_id = str(uuid.uuid4())
+                self._connections[key] = (conn, lock_id)
+                logger.debug("Advisory lock acquired for %s (pg_key=%d)", key, lock_key)
+                return lock_id
+            else:
+                await conn.close()
+                return None
+
+    async def release_lock(self, key: str, lock_id: str) -> bool:
+        """Release an advisory lock and close its connection."""
+        async with self._conn_lock:
+            entry = self._connections.get(key)
+            if not entry:
+                return False
+
+            conn, stored_lock_id = entry
+            if stored_lock_id != lock_id:
+                return False
+
+            lock_key = self._key_to_int(key)
+            from sqlalchemy import text
+
+            try:
+                await conn.execute(text("SELECT pg_advisory_unlock(:key)"), {"key": lock_key})
+                await conn.close()
+            except Exception as e:
+                logger.warning("Error releasing advisory lock for %s: %s", key, e)
+            finally:
+                del self._connections[key]
+
+            return True
+
+    async def is_locked(self, key: str) -> bool:
+        """
+        Check if the advisory lock is held by any session.
+
+        Queries pg_locks system view.
+        """
+        lock_key = self._key_to_int(key)
+        async with self._engine.connect() as conn:
+            from sqlalchemy import text
+
+            result = await conn.execute(
+                text(
+                    "SELECT 1 FROM pg_locks "
+                    "WHERE locktype = 'advisory' "
+                    "AND classid = (:key >> 32)::int "
+                    "AND objid = (:key & x'ffffffff'::bigint)::int "
+                    "AND granted = true"
+                ),
+                {"key": lock_key},
+            )
+            return result.fetchone() is not None
+
+    async def renew_lock(self, key: str, lock_id: str, ttl: int) -> bool:
+        """
+        No-op — advisory locks don't expire natively.
+
+        Returns True if we still hold the lock (connection alive).
+        """
+        async with self._conn_lock:
+            entry = self._connections.get(key)
+            if not entry:
+                return False
+            _, stored_lock_id = entry
+            return stored_lock_id == lock_id

--- a/fastapi_crons/retry.py
+++ b/fastapi_crons/retry.py
@@ -4,6 +4,7 @@ Retry decorator and utilities for job failures.
 This module provides a configurable retry mechanism for cron jobs
 with exponential backoff, jitter, and exception filtering.
 """
+
 import asyncio
 import functools
 import inspect
@@ -31,6 +32,7 @@ class RetryConfig:
         jitter: Whether to add random jitter to delay (helps prevent thundering herd)
         retry_on: Tuple of exception types to retry on (None = retry on all exceptions)
     """
+
     max_retries: int = 3
     retry_delay: float = 1.0
     backoff_multiplier: float = 2.0
@@ -42,7 +44,7 @@ class RetryConfig:
 
 def _calculate_delay(attempt: int, config: RetryConfig) -> float:
     """Calculate delay for the next retry attempt with exponential backoff."""
-    delay = config.retry_delay * (config.backoff_multiplier ** attempt)
+    delay = config.retry_delay * (config.backoff_multiplier**attempt)
     delay = min(delay, config.max_delay)
 
     if config.jitter:
@@ -112,6 +114,7 @@ def retry_on_failure(
 
     def decorator(func: Callable[P, T]) -> Callable[P, T]:
         if asyncio.iscoroutinefunction(func):
+
             @functools.wraps(func)
             async def async_wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
                 last_exception: Exception | None = None
@@ -142,8 +145,7 @@ def retry_on_failure(
                             await asyncio.sleep(delay)
                         else:
                             logger.error(
-                                f"All {config.max_retries + 1} attempts failed. "
-                                f"Last error: {e}"
+                                f"All {config.max_retries + 1} attempts failed. Last error: {e}"
                             )
 
                 # This should never be reached, but just in case
@@ -153,9 +155,11 @@ def retry_on_failure(
 
             return async_wrapper  # type: ignore
         else:
+
             @functools.wraps(func)
             def sync_wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
                 import time
+
                 last_exception: Exception | None = None
 
                 for attempt in range(config.max_retries + 1):
@@ -184,8 +188,7 @@ def retry_on_failure(
                             time.sleep(delay)
                         else:
                             logger.error(
-                                f"All {config.max_retries + 1} attempts failed. "
-                                f"Last error: {e}"
+                                f"All {config.max_retries + 1} attempts failed. Last error: {e}"
                             )
 
                 # This should never be reached, but just in case
@@ -233,7 +236,9 @@ async def execute_with_retry(
             last_exception = e
 
             if not _should_retry(e, config):
-                logger.debug(f"[{job_name}] Exception {type(e).__name__} not in retry list, raising")
+                logger.debug(
+                    f"[{job_name}] Exception {type(e).__name__} not in retry list, raising"
+                )
                 raise
 
             if attempt < config.max_retries:
@@ -252,8 +257,7 @@ async def execute_with_retry(
                 await asyncio.sleep(delay)
             else:
                 logger.error(
-                    f"[{job_name}] All {config.max_retries + 1} attempts failed. "
-                    f"Last error: {e}"
+                    f"[{job_name}] All {config.max_retries + 1} attempts failed. Last error: {e}"
                 )
 
     if last_exception:

--- a/fastapi_crons/runner.py
+++ b/fastapi_crons/runner.py
@@ -60,14 +60,16 @@ def calculate_retry_delay(
     """Calculate delay for the next retry attempt with exponential backoff and jitter."""
     import random
 
-    delay = base_delay * (backoff_multiplier ** attempt)
+    delay = base_delay * (backoff_multiplier**attempt)
     delay = min(delay, max_delay)
     # Add up to 25% jitter to prevent thundering herd
     jitter_amount = delay * 0.25 * random.random()
     return delay + jitter_amount
 
 
-async def run_job_loop(job: CronJob, state: StateBackend, lock_manager: DistributedLockManager, config: CronConfig) -> None:
+async def run_job_loop(
+    job: CronJob, state: StateBackend, lock_manager: DistributedLockManager, config: CronConfig
+) -> None:
     """Main job execution loop with distributed locking, retry, and timeout support."""
     logger.info(f"Starting job loop for '{job.name}' - next run at {job.next_run}")
 
@@ -136,14 +138,16 @@ async def run_job_loop(job: CronJob, state: StateBackend, lock_manager: Distribu
                         await state.set_job_status(job.name, "completed", config.instance_id)
 
                         # Update context with execution details
-                        context.update({
-                            "success": True,
-                            "start_time": start_time.isoformat(),
-                            "end_time": end_time.isoformat(),
-                            "duration": duration,
-                            "result": result,
-                            "attempts": attempt + 1,
-                        })
+                        context.update(
+                            {
+                                "success": True,
+                                "start_time": start_time.isoformat(),
+                                "end_time": end_time.isoformat(),
+                                "duration": duration,
+                                "result": result,
+                                "attempts": attempt + 1,
+                            }
+                        )
 
                         # Execute after_run hooks
                         for hook in job.after_run_hooks:
@@ -151,8 +155,12 @@ async def run_job_loop(job: CronJob, state: StateBackend, lock_manager: Distribu
 
                         # Log execution
                         await state.log_job_execution(
-                            job.name, config.instance_id, "completed",
-                            start_time, end_time, duration
+                            job.name,
+                            config.instance_id,
+                            "completed",
+                            start_time,
+                            end_time,
+                            duration,
                         )
 
                         logger.info(f"Job '{job.name}' completed successfully in {duration:.2f}s")
@@ -186,7 +194,9 @@ async def run_job_loop(job: CronJob, state: StateBackend, lock_manager: Distribu
                             break
 
                 # Handle final failure (after all retries)
-                if last_error is not None and (attempt >= max_retries or isinstance(last_error, JobTimeoutError)):
+                if last_error is not None and (
+                    attempt >= max_retries or isinstance(last_error, JobTimeoutError)
+                ):
                     end_time = datetime.now(timezone.utc)
                     duration = (end_time - start_time).total_seconds()
                     error = str(last_error)
@@ -196,15 +206,17 @@ async def run_job_loop(job: CronJob, state: StateBackend, lock_manager: Distribu
                     await state.set_job_status(job.name, "failed", config.instance_id)
 
                     # Update context with error details
-                    context.update({
-                        "success": False,
-                        "start_time": start_time.isoformat(),
-                        "end_time": end_time.isoformat(),
-                        "duration": duration,
-                        "error": error,
-                        "attempts": attempt + 1,
-                        "is_timeout": isinstance(last_error, JobTimeoutError),
-                    })
+                    context.update(
+                        {
+                            "success": False,
+                            "start_time": start_time.isoformat(),
+                            "end_time": end_time.isoformat(),
+                            "duration": duration,
+                            "error": error,
+                            "attempts": attempt + 1,
+                            "is_timeout": isinstance(last_error, JobTimeoutError),
+                        }
+                    )
 
                     # Execute on_error hooks
                     for hook in job.on_error_hooks:
@@ -212,8 +224,13 @@ async def run_job_loop(job: CronJob, state: StateBackend, lock_manager: Distribu
 
                     # Log execution
                     await state.log_job_execution(
-                        job.name, config.instance_id, "failed",
-                        start_time, end_time, duration, error
+                        job.name,
+                        config.instance_id,
+                        "failed",
+                        start_time,
+                        end_time,
+                        duration,
+                        error,
                     )
 
             finally:

--- a/fastapi_crons/scheduler.py
+++ b/fastapi_crons/scheduler.py
@@ -14,6 +14,7 @@ try:
     import redis.asyncio as redis
 
     from .locking import RedisLockBackend
+
     REDIS_AVAILABLE = True
 except ImportError:
     REDIS_AVAILABLE = False
@@ -24,10 +25,15 @@ logger = logging.getLogger(__name__)
 # Global instance to share jobs across decorators and scheduler
 _global_crons: Optional["Crons"] = None
 
+
 class Crons:
-    def __init__(self, app: Any | None = None, state_backend: StateBackend | None = None,
-                 lock_manager: DistributedLockManager | None = None,
-                 config: CronConfig | None = None) -> None:
+    def __init__(
+        self,
+        app: Any | None = None,
+        state_backend: StateBackend | None = None,
+        lock_manager: DistributedLockManager | None = None,
+        config: CronConfig | None = None,
+    ) -> None:
         global _global_crons
 
         self.jobs: list[CronJob] = []
@@ -43,11 +49,15 @@ class Crons:
         if self.lock_manager is None:
             if self.config.enable_distributed_locking and REDIS_AVAILABLE:
                 try:
-                    redis_client = redis.from_url(self.config.redis_url) if self.config.redis_url else redis.Redis(
-                        host=self.config.redis_host,
-                        port=self.config.redis_port,
-                        db=self.config.redis_db,
-                        password=self.config.redis_password
+                    redis_client = (
+                        redis.from_url(self.config.redis_url)
+                        if self.config.redis_url
+                        else redis.Redis(
+                            host=self.config.redis_host,
+                            port=self.config.redis_port,
+                            db=self.config.redis_db,
+                            password=self.config.redis_password,
+                        )
                     )
                     lock_backend = RedisLockBackend(redis_client)
                     self.lock_manager = DistributedLockManager(lock_backend, self.config)
@@ -73,7 +83,7 @@ class Crons:
         """Initialize with FastAPI app - automatically start/stop with app lifecycle."""
 
         # Check if app already has a lifespan
-        existing_lifespan = getattr(app.router, 'lifespan_context', None)
+        existing_lifespan = getattr(app.router, "lifespan_context", None)
 
         @asynccontextmanager
         async def lifespan_with_crons(app: Any):  # type: ignore
@@ -170,6 +180,7 @@ class Crons:
             retry_on: Tuple of exception types to retry on (None = retry on all exceptions)
             timeout: Job timeout in seconds (None = use config default, 0 = no timeout)
         """
+
         def wrapper(func: Callable) -> Callable:
             job = CronJob(
                 func,
@@ -193,6 +204,7 @@ class Crons:
                 self._tasks.append(task)
 
             return func
+
         return wrapper
 
     def get_jobs(self) -> list[CronJob]:
@@ -237,6 +249,7 @@ class Crons:
             for job in self.jobs:
                 job.add_on_error_hook(hook)
         return self
+
 
 # Convenience function to get the global crons instance
 def get_crons() -> Crons:

--- a/fastapi_crons/state/__init__.py
+++ b/fastapi_crons/state/__init__.py
@@ -10,10 +10,12 @@ logger = logging.getLogger("fastapi_cron.state")
 
 try:
     import redis.asyncio as redis
+
     REDIS_AVAILABLE = True
 except ImportError:
     REDIS_AVAILABLE = False
     redis = None
+
 
 class StateBackend(ABC):
     """Abstract base class for state backends."""
@@ -39,10 +41,18 @@ class StateBackend(ABC):
         """Get the status of a job."""
 
     @abstractmethod
-    async def log_job_execution(self, job_name: str, instance_id: str, status: str,
-                               started_at: datetime, completed_at: datetime | None = None,
-                               duration: float | None = None, error_message: str | None = None) -> None:
+    async def log_job_execution(
+        self,
+        job_name: str,
+        instance_id: str,
+        status: str,
+        started_at: datetime,
+        completed_at: datetime | None = None,
+        duration: float | None = None,
+        error_message: str | None = None,
+    ) -> None:
         """Log job execution details."""
+
 
 class SQLiteStateBackend(StateBackend):
     """SQLite-based state backend with thread safety and connection caching."""
@@ -117,7 +127,7 @@ class SQLiteStateBackend(StateBackend):
             await db.execute(
                 """INSERT OR REPLACE INTO job_state (name, last_run, updated_at)
                    VALUES (?, ?, ?)""",
-                (job_name, timestamp.isoformat(), datetime.now(timezone.utc).isoformat())
+                (job_name, timestamp.isoformat(), datetime.now(timezone.utc).isoformat()),
             )
             await db.commit()
 
@@ -148,14 +158,14 @@ class SQLiteStateBackend(StateBackend):
                     """INSERT OR REPLACE INTO job_status
                        (name, status, instance_id, started_at, updated_at)
                        VALUES (?, ?, ?, ?, ?)""",
-                    (job_name, status, instance_id, now, now)
+                    (job_name, status, instance_id, now, now),
                 )
             else:
                 await db.execute(
                     """UPDATE job_status
                        SET status = ?, updated_at = ?
                        WHERE name = ? AND instance_id = ?""",
-                    (status, now, job_name, instance_id)
+                    (status, now, job_name, instance_id),
                 )
 
             await db.commit()
@@ -166,7 +176,7 @@ class SQLiteStateBackend(StateBackend):
         await self._ensure_tables(db)
         async with db.execute(
             "SELECT status, instance_id, started_at, updated_at FROM job_status WHERE name=?",
-            (job_name,)
+            (job_name,),
         ) as cursor:
             row = await cursor.fetchone()
             if row:
@@ -174,13 +184,20 @@ class SQLiteStateBackend(StateBackend):
                     "status": row[0],
                     "instance_id": row[1],
                     "started_at": row[2],
-                    "updated_at": row[3]
+                    "updated_at": row[3],
                 }
             return None
 
-    async def log_job_execution(self, job_name: str, instance_id: str, status: str,
-                               started_at: datetime, completed_at: datetime | None = None,
-                               duration: float | None = None, error_message: str | None = None) -> None:
+    async def log_job_execution(
+        self,
+        job_name: str,
+        instance_id: str,
+        status: str,
+        started_at: datetime,
+        completed_at: datetime | None = None,
+        duration: float | None = None,
+        error_message: str | None = None,
+    ) -> None:
         """Log job execution details."""
         async with self._lock:
             db = await self._get_connection()
@@ -189,11 +206,18 @@ class SQLiteStateBackend(StateBackend):
                 """INSERT INTO job_execution_log
                    (job_name, instance_id, status, started_at, completed_at, duration, error_message)
                    VALUES (?, ?, ?, ?, ?, ?, ?)""",
-                (job_name, instance_id, status, started_at.isoformat(),
-                 completed_at.isoformat() if completed_at else None,
-                 duration, error_message)
+                (
+                    job_name,
+                    instance_id,
+                    status,
+                    started_at.isoformat(),
+                    completed_at.isoformat() if completed_at else None,
+                    duration,
+                    error_message,
+                ),
             )
             await db.commit()
+
 
 class RedisStateBackend(StateBackend):
     """Redis-based state backend for distributed deployments."""
@@ -233,7 +257,7 @@ class RedisStateBackend(StateBackend):
         status_data: dict[str, str] = {
             "status": status,
             "instance_id": instance_id,
-            "updated_at": datetime.now(timezone.utc).isoformat()
+            "updated_at": datetime.now(timezone.utc).isoformat(),
         }
 
         if status == "running":
@@ -253,9 +277,16 @@ class RedisStateBackend(StateBackend):
             return {k.decode(): v.decode() for k, v in result.items()}
         return None
 
-    async def log_job_execution(self, job_name: str, instance_id: str, status: str,
-                               started_at: datetime, completed_at: datetime | None = None,
-                               duration: float | None = None, error_message: str | None = None) -> None:
+    async def log_job_execution(
+        self,
+        job_name: str,
+        instance_id: str,
+        status: str,
+        started_at: datetime,
+        completed_at: datetime | None = None,
+        duration: float | None = None,
+        error_message: str | None = None,
+    ) -> None:
         """Log job execution details to Redis."""
         import json
 
@@ -270,7 +301,7 @@ class RedisStateBackend(StateBackend):
             "completed_at": completed_at.isoformat() if completed_at else None,
             "duration": duration,
             "error_message": error_message,
-            "created_at": datetime.now(timezone.utc).isoformat()
+            "created_at": datetime.now(timezone.utc).isoformat(),
         }
 
         await self.redis.set(log_key, json.dumps(log_data))

--- a/fastapi_crons/state/sqlalchemy.py
+++ b/fastapi_crons/state/sqlalchemy.py
@@ -1,0 +1,338 @@
+"""
+SQLAlchemy state backend for fastapi-crons.
+
+Supports both sync and async SQLAlchemy engines.
+Install with: pip install fastapi-crons[sqlalchemy]
+
+Usage:
+    # Async engine (recommended for FastAPI)
+    from sqlalchemy.ext.asyncio import create_async_engine
+    from fastapi_crons.state.sqlalchemy import SQLAlchemyStateBackend
+
+    engine = create_async_engine("postgresql+asyncpg://user:pass@host/db")
+    backend = SQLAlchemyStateBackend(engine)
+
+    # Sync engine
+    from sqlalchemy import create_engine
+    engine = create_engine("postgresql://user:pass@host/db")
+    backend = SQLAlchemyStateBackend(engine)
+
+Alembic integration (env.py):
+    from fastapi_crons.state.sqlalchemy import cron_metadata
+    target_metadata = [Base.metadata, cron_metadata]
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, cast
+
+from fastapi_crons.state import StateBackend
+
+logger = logging.getLogger("fastapi_cron.state.sqlalchemy")
+
+try:
+    from sqlalchemy import Float, Insert, Integer, MetaData, String, Text, select
+    from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+except ImportError as e:
+    raise ImportError(
+        "SQLAlchemy is required for SQLAlchemyStateBackend.\n"
+        "Install with: pip install fastapi-crons[sqlalchemy]"
+    ) from e
+
+
+if TYPE_CHECKING:
+    from sqlalchemy import Engine
+    from sqlalchemy.ext.asyncio import AsyncEngine
+
+
+class _CronBase(DeclarativeBase):
+    """Private declarative base for fastapi-crons tables."""
+
+
+class _JobState(_CronBase):
+    """Tracks the last run timestamp per job."""
+
+    __tablename__ = "cron_job_state"
+
+    name: Mapped[str] = mapped_column(String(255), primary_key=True)
+    last_run: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    created_at: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    updated_at: Mapped[str | None] = mapped_column(String(50), nullable=True)
+
+
+class _JobStatus(_CronBase):
+    """Tracks the current execution status per job."""
+
+    __tablename__ = "cron_job_status"
+
+    name: Mapped[str] = mapped_column(String(255), primary_key=True)
+    status: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    instance_id: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    started_at: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    updated_at: Mapped[str | None] = mapped_column(String(50), nullable=True)
+
+
+class _JobExecutionLog(_CronBase):
+    """Append-only execution history."""
+
+    __tablename__ = "cron_job_execution_log"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    job_name: Mapped[str | None] = mapped_column(String(255), nullable=True, index=True)
+    instance_id: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    status: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    started_at: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    completed_at: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    duration: Mapped[float | None] = mapped_column(Float, nullable=True)
+    error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[str | None] = mapped_column(String(50), nullable=True)
+
+
+cron_metadata: MetaData = _CronBase.metadata
+"""
+SQLAlchemy MetaData containing all fastapi-crons tables.
+
+Use in your Alembic env.py to merge cron tables into your migration flow:
+
+    from fastapi_crons.state.sqlalchemy import cron_metadata
+    target_metadata = [Base.metadata, cron_metadata]
+"""
+
+
+def _upsert(
+    table: type, dialect_name: str, values: dict[str, Any], set_cols: dict[str, Any]
+) -> Insert:
+    """
+    Build a dialect-native upsert statement.
+
+    - PostgreSQL : INSERT ... ON CONFLICT DO UPDATE SET ...
+    - SQLite     : INSERT ... ON CONFLICT DO UPDATE SET ...
+    - MySQL/Maria: INSERT ... ON DUPLICATE KEY UPDATE ...
+    """
+    if dialect_name in ("mysql", "mariadb"):
+        from sqlalchemy.dialects.mysql import insert as mysql_insert
+
+        return mysql_insert(table).values(**values).on_duplicate_key_update(**set_cols)
+
+    if dialect_name == "postgresql":
+        from sqlalchemy.dialects.postgresql import insert as insert
+    elif dialect_name == "sqlite":
+        from sqlalchemy.dialects.sqlite import insert as insert  # type: ignore[assignment]
+    else:
+        raise NotImplementedError(
+            f"Unsupported dialect: {dialect_name!r}. Supported: postgresql, sqlite, mysql, mariadb."
+        )
+
+    return (
+        insert(table).values(**values).on_conflict_do_update(index_elements=["name"], set_=set_cols)
+    )
+
+
+class SQLAlchemyStateBackend(StateBackend):
+    """
+    SQLAlchemy-based state backend for fastapi-crons.
+
+    Accepts both sync (Engine) and async (AsyncEngine) SQLAlchemy engines.
+    The backend detects the engine type at initialization and dispatches
+    database operations accordingly.
+
+    Args:
+        engine: A SQLAlchemy Engine or AsyncEngine instance.
+
+    Example:
+        # Async (recommended for FastAPI)
+        engine = create_async_engine("postgresql+asyncpg://...")
+        backend = SQLAlchemyStateBackend(engine)
+
+        # Sync
+        engine = create_engine("postgresql://...")
+        backend = SQLAlchemyStateBackend(engine)
+
+        # Pass to Crons
+        crons = Crons(app, state_backend=backend)
+    """
+
+    def __init__(self, engine: Engine | AsyncEngine, create_tables: bool = True) -> None:
+        try:
+            from sqlalchemy.ext.asyncio import AsyncEngine
+
+            self._is_async: bool = isinstance(engine, AsyncEngine)
+        except ImportError:
+            self._is_async = False
+
+        self._engine = engine
+        self._dialect: str = engine.dialect.name
+        self._create_tables = create_tables
+        self._tables_created: bool = False
+        self._init_lock: asyncio.Lock = asyncio.Lock()
+
+        logger.debug(
+            "SQLAlchemyStateBackend initialized — dialect=%s async=%s",
+            self._dialect,
+            self._is_async,
+        )
+
+    async def _ensure_tables(self) -> None:
+        """Create tables if they don't exist — guarded by asyncio.Lock."""
+        if not self._create_tables or self._tables_created:
+            return
+        async with self._init_lock:
+            if self._tables_created:
+                return
+            await self._run(None, create_all=True)
+            self._tables_created = True
+
+    async def _run(self, stmt: Any, *, create_all: bool = False) -> Any:
+        """
+        Execute a Core statement against the engine.
+
+        AsyncEngine  → native async execution
+        Engine (sync) → asyncio.to_thread to avoid blocking the event loop
+        """
+        if self._is_async:
+            async with self._engine.begin() as conn:  # type: ignore
+                if create_all:
+                    await conn.run_sync(_CronBase.metadata.create_all)
+                    return None
+                return await conn.execute(stmt)
+        else:
+
+            def _blocking() -> Any:
+                with self._engine.begin() as _conn:  # type: ignore
+                    if create_all:
+                        _CronBase.metadata.create_all(_conn)
+                        return None
+                    return _conn.execute(stmt)
+
+            return await asyncio.to_thread(_blocking)
+
+    async def set_last_run(self, job_name: str, timestamp: datetime) -> None:
+        """Upsert the last run timestamp for a job."""
+        await self._ensure_tables()
+        now = datetime.now(timezone.utc).isoformat()
+        values = {"name": job_name, "last_run": timestamp.isoformat(), "updated_at": now}
+        stmt = _upsert(
+            _JobState, self._dialect, values, {k: v for k, v in values.items() if k != "name"}
+        )
+        await self._run(stmt)
+
+    async def get_last_run(self, job_name: str) -> str | None:
+        """Get the last run timestamp for a job."""
+        await self._ensure_tables()
+        result = await self._run(select(_JobState.last_run).where(_JobState.name == job_name))
+        row = result.fetchone()
+        return row[0] if row else None
+
+    async def get_all_jobs(self) -> list[tuple[str, str | None]]:
+        """Get all jobs and their last run timestamps, ordered by name."""
+        await self._ensure_tables()
+        result = await self._run(
+            select(_JobState.name, _JobState.last_run).order_by(_JobState.name)
+        )
+        return list(result.fetchall())
+
+    async def set_job_status(self, job_name: str, status: str, instance_id: str) -> None:
+        """
+        Upsert the status of a job.
+
+        On INSERT  : all columns including started_at are written.
+        On UPDATE  : started_at is preserved when transitioning to
+                     completed/failed (only status, instance_id, updated_at change).
+        """
+        await self._ensure_tables()
+        now = datetime.now(timezone.utc).isoformat()
+
+        if status == "running":
+            values: dict[str, Any] = {
+                "name": job_name,
+                "status": status,
+                "instance_id": instance_id,
+                "started_at": now,
+                "updated_at": now,
+            }
+            set_cols = {k: v for k, v in values.items() if k != "name"}
+        else:
+            values = {
+                "name": job_name,
+                "status": status,
+                "instance_id": instance_id,
+                "started_at": None,
+                "updated_at": now,
+            }
+            set_cols = {"status": status, "instance_id": instance_id, "updated_at": now}
+
+        stmt = _upsert(_JobStatus, self._dialect, values, set_cols)
+        await self._run(stmt)
+
+    async def get_job_status(self, job_name: str) -> dict[str, Any] | None:
+        """Get the current status dict for a job."""
+        await self._ensure_tables()
+        result = await self._run(
+            select(
+                _JobStatus.status,
+                _JobStatus.instance_id,
+                _JobStatus.started_at,
+                _JobStatus.updated_at,
+            ).where(_JobStatus.name == job_name)
+        )
+        row = result.fetchone()
+        if row:
+            return {
+                "status": row[0],
+                "instance_id": row[1],
+                "started_at": row[2],
+                "updated_at": row[3],
+            }
+        return None
+
+    async def log_job_execution(
+        self,
+        job_name: str,
+        instance_id: str,
+        status: str,
+        started_at: datetime,
+        completed_at: datetime | None = None,
+        duration: float | None = None,
+        error_message: str | None = None,
+    ) -> None:
+        """Append an execution record to the log table (pure INSERT, no upsert)."""
+        await self._ensure_tables()
+        from sqlalchemy import insert as sa_insert
+
+        stmt = sa_insert(_JobExecutionLog).values(
+            job_name=job_name,
+            instance_id=instance_id,
+            status=status,
+            started_at=started_at.isoformat(),
+            completed_at=completed_at.isoformat() if completed_at else None,
+            duration=duration,
+            error_message=error_message,
+            created_at=datetime.now(timezone.utc).isoformat(),
+        )
+        await self._run(stmt)
+
+    async def dispose(self) -> None:
+        """Dispose the engine connection pool gracefully."""
+        if self._is_async:
+            await cast(AsyncEngine, self._engine).dispose()
+        else:
+            await asyncio.to_thread(self._engine.dispose)
+
+
+SQLModelStateBackend = SQLAlchemyStateBackend
+"""
+Alias of SQLAlchemyStateBackend for projects using SQLModel.
+
+SQLModel engines are fully SQLAlchemy-compatible — no separate
+implementation is needed. This alias exists purely for discoverability.
+
+Usage:
+    from sqlmodel import create_engine
+    from fastapi_crons.state.sqlalchemy import SQLModelStateBackend
+
+    engine = create_engine("postgresql://...")
+    backend = SQLModelStateBackend(engine)
+"""

--- a/fastapi_crons/telemetry.py
+++ b/fastapi_crons/telemetry.py
@@ -7,6 +7,7 @@ for cron job monitoring and observability.
 Note: This module requires the opentelemetry-api and opentelemetry-sdk packages.
 Install with: pip install fastapi-crons[otel]
 """
+
 import logging
 from typing import Any
 
@@ -16,6 +17,7 @@ logger = logging.getLogger("fastapi_cron.telemetry")
 try:
     from opentelemetry import metrics, trace
     from opentelemetry.trace import SpanKind, Status, StatusCode
+
     OTEL_AVAILABLE = True
 except ImportError:
     OTEL_AVAILABLE = False
@@ -251,7 +253,9 @@ class OpenTelemetryHooks:
                     1,
                     attributes={
                         "job_name": job_name,
-                        "error_type": type(error).__name__ if isinstance(error, Exception) else "str",
+                        "error_type": type(error).__name__
+                        if isinstance(error, Exception)
+                        else "str",
                         "tags": ",".join(tags) if tags else "",
                     },
                 )
@@ -281,7 +285,7 @@ def is_otel_available() -> bool:
 
 def get_recommended_otel_setup() -> str:
     """Return recommended OpenTelemetry setup code."""
-    return '''
+    return """
 # Recommended OpenTelemetry setup for fastapi-crons
 
 from opentelemetry import trace, metrics
@@ -308,4 +312,4 @@ otel_hooks = OpenTelemetryHooks(service_name="my-cron-service")
 crons.add_before_run_hook(otel_hooks.before_run)
 crons.add_after_run_hook(otel_hooks.after_run)
 crons.add_on_error_hook(otel_hooks.on_error)
-'''
+"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
   "rich",
   "redis",
   "pydantic>=2.0.0",
-  "aiohttp"
+  "aiohttp",
 ]
 requires-python = ">=3.10"
 
@@ -34,11 +34,19 @@ dev = [
   "types-aiofiles",
   "types-redis",
   "build>=1.0.0",
+  "httpx>=0.28.1",
   "twine>=4.0.0",
 ]
 otel = [
   "opentelemetry-api>=1.0.0",
   "opentelemetry-sdk>=1.0.0",
+]
+sqlalchemy = [
+    "sqlalchemy[asyncio]>=2.0.47",
+]
+sqlmodel = [
+    "sqlalchemy[asyncio]>=2.0.47",
+    "sqlmodel>=0.0.37",
 ]
 
 [project.urls]
@@ -66,6 +74,11 @@ python_version = "3.10"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true
+
+[[tool.mypy.overrides]]
+module = "tests.*"
+disallow_untyped_defs = false
+disallow_incomplete_defs = false
 
 [tool.coverage.run]
 source = ["fastapi_crons"]

--- a/scripts/setup_dev_env.py
+++ b/scripts/setup_dev_env.py
@@ -21,6 +21,7 @@ def run_command(cmd, description):
         print(f"❌ {description} failed!")
         return False
 
+
 def main():
     """Main setup function"""
     print("🚀 Setting up fastapi-crons development environment...\n")
@@ -30,10 +31,7 @@ def main():
     os.chdir(project_root)
 
     # Install dependencies
-    if not run_command(
-        "pip install -e '.[dev]'",
-        "Installing dependencies"
-    ):
+    if not run_command("pip install -e '.[dev]'", "Installing dependencies"):
         sys.exit(1)
 
     # Make scripts executable
@@ -63,6 +61,7 @@ def main():
     print("  ./scripts/build.sh         - Build package")
     print("  ./scripts/clean.sh         - Clean build artifacts")
     print("  ./scripts/ci.sh            - Run full CI pipeline")
+
 
 if __name__ == "__main__":
     main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Pytest configuration and shared fixtures for fastapi-crons tests."""
+
 import gc
 import os
 import tempfile
@@ -70,11 +71,7 @@ async def crons_instance(sqlite_backend, lock_manager, cron_config):
     """Create a Crons instance for testing."""
     # Reset global state to ensure test isolation
     reset_global_crons()
-    crons = Crons(
-        state_backend=sqlite_backend,
-        lock_manager=lock_manager,
-        config=cron_config
-    )
+    crons = Crons(state_backend=sqlite_backend, lock_manager=lock_manager, config=cron_config)
     return crons
 
 
@@ -90,9 +87,6 @@ async def crons_with_app(fastapi_app, sqlite_backend, lock_manager, cron_config)
     # Reset global state to ensure test isolation
     reset_global_crons()
     crons = Crons(
-        app=fastapi_app,
-        state_backend=sqlite_backend,
-        lock_manager=lock_manager,
-        config=cron_config
+        app=fastapi_app, state_backend=sqlite_backend, lock_manager=lock_manager, config=cron_config
     )
     return crons

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,5 @@
 """Tests for CronConfig class."""
+
 from fastapi_crons import CronConfig
 
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,4 +1,5 @@
 """Tests for job hooks functionality."""
+
 import asyncio
 
 import pytest
@@ -46,10 +47,7 @@ class TestHooks:
         received_context = []
 
         def hook(job_name, context):
-            received_context.append({
-                "job_name": job_name,
-                "context": context
-            })
+            received_context.append({"job_name": job_name, "context": context})
 
         def job_func():
             pass
@@ -58,11 +56,7 @@ class TestHooks:
         job.add_before_run_hook(hook)
 
         # Simulate hook execution
-        context = {
-            "job_name": "my_job",
-            "tags": ["test"],
-            "timestamp": "2024-01-01T00:00:00"
-        }
+        context = {"job_name": "my_job", "tags": ["test"], "timestamp": "2024-01-01T00:00:00"}
         hook("my_job", context)
 
         assert len(received_context) == 1
@@ -100,10 +94,7 @@ class TestHooks:
         error_context = []
 
         def error_hook(job_name, context):
-            error_context.append({
-                "job_name": job_name,
-                "error": context.get("error")
-            })
+            error_context.append({"job_name": job_name, "error": context.get("error")})
 
         def job_func():
             pass
@@ -112,11 +103,7 @@ class TestHooks:
         job.add_on_error_hook(error_hook)
 
         # Simulate error
-        context = {
-            "job_name": "failing_job",
-            "error": "Job execution failed",
-            "success": False
-        }
+        context = {"job_name": "failing_job", "error": "Job execution failed", "success": False}
         error_hook("failing_job", context)
 
         assert len(error_context) == 1

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,4 +1,5 @@
 """Integration tests for fastapi-crons."""
+
 import asyncio
 import inspect
 
@@ -41,7 +42,7 @@ class TestIntegration:
             app=fastapi_app,
             state_backend=sqlite_backend,
             lock_manager=lock_manager,
-            config=cron_config
+            config=cron_config,
         )
 
         @crons.cron("*/5 * * * *", name="periodic_task")
@@ -61,17 +62,9 @@ class TestIntegration:
 
     def test_multiple_crons_instances(self, sqlite_backend, lock_manager, cron_config):
         """Test multiple Crons instances."""
-        crons1 = Crons(
-            state_backend=sqlite_backend,
-            lock_manager=lock_manager,
-            config=cron_config
-        )
+        crons1 = Crons(state_backend=sqlite_backend, lock_manager=lock_manager, config=cron_config)
 
-        crons2 = Crons(
-            state_backend=sqlite_backend,
-            lock_manager=lock_manager,
-            config=cron_config
-        )
+        crons2 = Crons(state_backend=sqlite_backend, lock_manager=lock_manager, config=cron_config)
 
         @crons1.cron("* * * * *", name="job1")
         def job1():

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1,4 +1,5 @@
 """Tests for CronJob class and job creation."""
+
 from datetime import datetime, timezone
 
 import pytest
@@ -12,6 +13,7 @@ class TestCronJob:
 
     def test_job_creation(self):
         """Test basic job creation."""
+
         def sample_job():
             pass
 
@@ -25,6 +27,7 @@ class TestCronJob:
 
     def test_job_with_tags(self):
         """Test job creation with tags."""
+
         def sample_job():
             pass
 
@@ -34,6 +37,7 @@ class TestCronJob:
 
     def test_job_name_defaults_to_function_name(self):
         """Test that job name defaults to function name."""
+
         def my_function():
             pass
 
@@ -42,6 +46,7 @@ class TestCronJob:
 
     def test_job_next_run_calculation(self):
         """Test that next_run is calculated correctly."""
+
         def sample_job():
             pass
 
@@ -54,6 +59,7 @@ class TestCronJob:
 
     def test_job_update_next_run(self):
         """Test updating next_run timestamp."""
+
         def sample_job():
             pass
 
@@ -69,6 +75,7 @@ class TestCronJob:
 
     def test_job_hooks_initialization(self):
         """Test that job hooks are initialized as empty lists."""
+
         def sample_job():
             pass
 
@@ -80,6 +87,7 @@ class TestCronJob:
 
     def test_add_before_run_hook(self):
         """Test adding a before_run hook."""
+
         def sample_job():
             pass
 
@@ -94,6 +102,7 @@ class TestCronJob:
 
     def test_add_after_run_hook(self):
         """Test adding an after_run hook."""
+
         def sample_job():
             pass
 
@@ -108,6 +117,7 @@ class TestCronJob:
 
     def test_add_on_error_hook(self):
         """Test adding an on_error hook."""
+
         def sample_job():
             pass
 
@@ -122,6 +132,7 @@ class TestCronJob:
 
     def test_multiple_hooks(self):
         """Test adding multiple hooks of the same type."""
+
         def sample_job():
             pass
 
@@ -141,6 +152,7 @@ class TestCronJob:
 
     def test_cron_expression_validation(self):
         """Test that invalid cron expressions raise errors."""
+
         def sample_job():
             pass
 
@@ -149,17 +161,18 @@ class TestCronJob:
 
     def test_valid_cron_expressions(self):
         """Test various valid cron expressions."""
+
         def sample_job():
             pass
 
         valid_expressions = [
-            "* * * * *",           # Every minute
-            "*/5 * * * *",         # Every 5 minutes
-            "0 * * * *",           # Every hour
-            "0 0 * * *",           # Daily at midnight
-            "0 0 * * 0",           # Weekly on Sunday
-            "0 0 1 * *",           # Monthly on 1st
-            "0 0 1 1 *",           # Yearly on Jan 1st
+            "* * * * *",  # Every minute
+            "*/5 * * * *",  # Every 5 minutes
+            "0 * * * *",  # Every hour
+            "0 0 * * *",  # Daily at midnight
+            "0 0 * * 0",  # Weekly on Sunday
+            "0 0 1 * *",  # Monthly on 1st
+            "0 0 1 1 *",  # Yearly on Jan 1st
         ]
 
         for expr in valid_expressions:

--- a/tests/test_locking_sqlalchemy.py
+++ b/tests/test_locking_sqlalchemy.py
@@ -1,0 +1,229 @@
+"""Tests for SQLAlchemy lock backends — SQLAlchemyLockBackend."""
+
+import asyncio
+from datetime import datetime, timezone
+
+import pytest
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+@pytest.fixture
+async def sa_async_engine_lock():
+    pytest.importorskip("sqlalchemy", reason="pip install fastapi-crons[sqlalchemy]")
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    yield engine
+    await engine.dispose()
+
+
+@pytest.fixture
+async def sa_async_engine_fresh():
+    """Dedicated fresh engine for no-auto-create tests."""
+    pytest.importorskip("sqlalchemy", reason="pip install fastapi-crons[sqlalchemy]")
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    yield engine
+    await engine.dispose()
+
+
+@pytest.fixture
+def sa_sync_engine_lock(tmp_path):
+    pytest.importorskip("sqlalchemy", reason="pip install fastapi-crons[sqlalchemy]")
+    from sqlalchemy import create_engine
+
+    engine = create_engine(f"sqlite:///{tmp_path / 'test_locks.db'}")
+    yield engine
+    engine.dispose()
+
+
+@pytest.fixture
+def sa_sync_engine_fresh(tmp_path):
+    """Dedicated fresh engine for no-auto-create tests."""
+    pytest.importorskip("sqlalchemy", reason="pip install fastapi-crons[sqlalchemy]")
+    from sqlalchemy import create_engine
+
+    engine = create_engine(f"sqlite:///{tmp_path / 'test_locks_fresh.db'}")
+    yield engine
+    engine.dispose()
+
+
+@pytest.fixture
+async def lock_backend_async(sa_async_engine_lock):
+    from fastapi_crons.locking.sqlalchemy import SQLAlchemyLockBackend
+
+    return SQLAlchemyLockBackend(sa_async_engine_lock, create_tables=True)
+
+
+@pytest.fixture
+def lock_backend_sync(sa_sync_engine_lock):
+    from fastapi_crons.locking.sqlalchemy import SQLAlchemyLockBackend
+
+    return SQLAlchemyLockBackend(sa_sync_engine_lock, create_tables=True)
+
+
+class TestSQLAlchemyLockBackendAsync:
+    @pytest.mark.asyncio
+    async def test_acquire_returns_lock_id(self, lock_backend_async):
+        lock_id = await lock_backend_async.acquire_lock("job:test", ttl=60)
+        assert lock_id is not None
+        assert len(lock_id) == 36
+
+    @pytest.mark.asyncio
+    async def test_acquire_same_key_twice_fails(self, lock_backend_async):
+        await lock_backend_async.acquire_lock("job:test", ttl=60)
+        second = await lock_backend_async.acquire_lock("job:test", ttl=60)
+        assert second is None
+
+    @pytest.mark.asyncio
+    async def test_acquire_different_keys(self, lock_backend_async):
+        id1 = await lock_backend_async.acquire_lock("job:a", ttl=60)
+        id2 = await lock_backend_async.acquire_lock("job:b", ttl=60)
+        assert id1 is not None
+        assert id2 is not None
+        assert id1 != id2
+
+    @pytest.mark.asyncio
+    async def test_is_locked_true_after_acquire(self, lock_backend_async):
+        await lock_backend_async.acquire_lock("job:test", ttl=60)
+        assert await lock_backend_async.is_locked("job:test") is True
+
+    @pytest.mark.asyncio
+    async def test_is_locked_false_before_acquire(self, lock_backend_async):
+        assert await lock_backend_async.is_locked("job:test") is False
+
+    @pytest.mark.asyncio
+    async def test_release_owned_lock(self, lock_backend_async):
+        lock_id = await lock_backend_async.acquire_lock("job:test", ttl=60)
+        result = await lock_backend_async.release_lock("job:test", lock_id)
+        assert result is True
+        assert await lock_backend_async.is_locked("job:test") is False
+
+    @pytest.mark.asyncio
+    async def test_release_wrong_lock_id(self, lock_backend_async):
+        await lock_backend_async.acquire_lock("job:test", ttl=60)
+        result = await lock_backend_async.release_lock("job:test", "wrong-id")
+        assert result is False
+        assert await lock_backend_async.is_locked("job:test") is True
+
+    @pytest.mark.asyncio
+    async def test_release_nonexistent_lock(self, lock_backend_async):
+        result = await lock_backend_async.release_lock("job:ghost", "any-id")
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_reacquire_after_release(self, lock_backend_async):
+        lock_id = await lock_backend_async.acquire_lock("job:test", ttl=60)
+        await lock_backend_async.release_lock("job:test", lock_id)
+        new_id = await lock_backend_async.acquire_lock("job:test", ttl=60)
+        assert new_id is not None
+
+    @pytest.mark.asyncio
+    async def test_renew_owned_lock(self, lock_backend_async):
+        lock_id = await lock_backend_async.acquire_lock("job:test", ttl=60)
+        result = await lock_backend_async.renew_lock("job:test", lock_id, ttl=120)
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_renew_wrong_lock_id(self, lock_backend_async):
+        await lock_backend_async.acquire_lock("job:test", ttl=60)
+        result = await lock_backend_async.renew_lock("job:test", "wrong-id", ttl=120)
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_renew_nonexistent_lock(self, lock_backend_async):
+        result = await lock_backend_async.renew_lock("job:ghost", "any-id", ttl=60)
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_expired_lock_can_be_reacquired(self, lock_backend_async):
+        """Expired locks are cleaned up passively on next acquire."""
+        lock_id = await lock_backend_async.acquire_lock("job:test", ttl=1)
+        assert lock_id is not None
+
+        from sqlalchemy import update
+
+        from fastapi_crons.locking.sqlalchemy import _CronLock
+
+        past = "2000-01-01T00:00:00+00:00"
+        async with lock_backend_async._engine.begin() as conn:
+            await conn.execute(
+                update(_CronLock).where(_CronLock.key == "job:test").values(expires_at=past)
+            )
+
+        new_id = await lock_backend_async.acquire_lock("job:test", ttl=60)
+        assert new_id is not None
+
+    @pytest.mark.asyncio
+    async def test_tables_created_once(self, lock_backend_async):
+        await asyncio.gather(
+            lock_backend_async.acquire_lock("job:a", ttl=60),
+            lock_backend_async.acquire_lock("job:b", ttl=60),
+        )
+        assert lock_backend_async._tables_created is True
+
+
+class TestSQLAlchemyLockBackendSync:
+    @pytest.mark.asyncio
+    async def test_acquire_returns_lock_id(self, lock_backend_sync):
+        lock_id = await lock_backend_sync.acquire_lock("job:test", ttl=60)
+        assert lock_id is not None
+
+    @pytest.mark.asyncio
+    async def test_acquire_same_key_twice_fails(self, lock_backend_sync):
+        await lock_backend_sync.acquire_lock("job:test", ttl=60)
+        second = await lock_backend_sync.acquire_lock("job:test", ttl=60)
+        assert second is None
+
+    @pytest.mark.asyncio
+    async def test_is_locked_after_acquire(self, lock_backend_sync):
+        await lock_backend_sync.acquire_lock("job:test", ttl=60)
+        assert await lock_backend_sync.is_locked("job:test") is True
+
+    @pytest.mark.asyncio
+    async def test_release_owned_lock(self, lock_backend_sync):
+        lock_id = await lock_backend_sync.acquire_lock("job:test", ttl=60)
+        assert await lock_backend_sync.release_lock("job:test", lock_id) is True
+        assert await lock_backend_sync.is_locked("job:test") is False
+
+    @pytest.mark.asyncio
+    async def test_renew_owned_lock(self, lock_backend_sync):
+        lock_id = await lock_backend_sync.acquire_lock("job:test", ttl=60)
+        assert await lock_backend_sync.renew_lock("job:test", lock_id, ttl=120) is True
+
+
+class TestSQLAlchemyLockBackendNoAutoCreate:
+    @pytest.mark.asyncio
+    async def test_no_auto_create_raises_on_missing_table(self, sa_async_engine_fresh):
+        from sqlalchemy.exc import OperationalError
+
+        from fastapi_crons.locking.sqlalchemy import SQLAlchemyLockBackend
+
+        backend = SQLAlchemyLockBackend(sa_async_engine_fresh, create_tables=False)
+        with pytest.raises(OperationalError):
+            await backend.acquire_lock("job:test", ttl=60)
+
+    @pytest.mark.asyncio
+    async def test_no_auto_create_works_after_manual_create(self, sa_async_engine_fresh):
+        from fastapi_crons.locking.sqlalchemy import SQLAlchemyLockBackend, cron_locks_metadata
+
+        async with sa_async_engine_fresh.begin() as conn:
+            await conn.run_sync(cron_locks_metadata.create_all)
+
+        backend = SQLAlchemyLockBackend(sa_async_engine_fresh, create_tables=False)
+        lock_id = await backend.acquire_lock("job:test", ttl=60)
+        assert lock_id is not None
+
+    @pytest.mark.asyncio
+    async def test_no_auto_create_sync_raises(self, sa_sync_engine_fresh):
+        from fastapi_crons.locking.sqlalchemy import SQLAlchemyLockBackend
+
+        backend = SQLAlchemyLockBackend(sa_sync_engine_fresh, create_tables=False)
+        from sqlalchemy.exc import OperationalError
+
+        with pytest.raises(OperationalError):
+            await backend.acquire_lock("job:test", ttl=60)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -19,16 +19,13 @@ class TestCronsScheduler:
         config = CronConfig()
         config.enable_distributed_locking = True
 
-        crons = Crons(
-            state_backend=sqlite_backend,
-            lock_manager=lock_manager,
-            config=config
-        )
+        crons = Crons(state_backend=sqlite_backend, lock_manager=lock_manager, config=config)
 
         assert crons.config.enable_distributed_locking is True
 
     def test_register_job_with_decorator(self, crons_instance):
         """Test registering a job with decorator."""
+
         @crons_instance.cron("*/5 * * * *", name="test_job")
         def my_job():
             pass
@@ -38,6 +35,7 @@ class TestCronsScheduler:
 
     def test_register_multiple_jobs(self, crons_instance):
         """Test registering multiple jobs."""
+
         @crons_instance.cron("*/5 * * * *", name="job1")
         def job1():
             pass
@@ -50,6 +48,7 @@ class TestCronsScheduler:
 
     def test_get_jobs(self, crons_instance):
         """Test retrieving all jobs."""
+
         @crons_instance.cron("* * * * *", name="job1")
         def job1():
             pass
@@ -60,6 +59,7 @@ class TestCronsScheduler:
 
     def test_get_job_by_name(self, crons_instance):
         """Test retrieving a specific job by name."""
+
         @crons_instance.cron("* * * * *", name="specific_job")
         def specific_job_func():
             pass
@@ -75,6 +75,7 @@ class TestCronsScheduler:
 
     def test_add_before_run_hook_to_specific_job(self, crons_instance):
         """Test adding a hook to a specific job."""
+
         @crons_instance.cron("* * * * *", name="job1")
         def job1():
             pass
@@ -89,6 +90,7 @@ class TestCronsScheduler:
 
     def test_add_hook_to_all_jobs(self, crons_instance):
         """Test adding a hook to all jobs."""
+
         @crons_instance.cron("* * * * *", name="job1")
         def job1():
             pass
@@ -107,6 +109,7 @@ class TestCronsScheduler:
 
     def test_hook_chaining(self, crons_instance):
         """Test method chaining for hook addition."""
+
         @crons_instance.cron("* * * * *", name="job1")
         def job1():
             pass
@@ -117,15 +120,14 @@ class TestCronsScheduler:
         def hook2(job_name, context):
             pass
 
-        result = (crons_instance
-                  .add_before_run_hook(hook1)
-                  .add_after_run_hook(hook2))
+        result = crons_instance.add_before_run_hook(hook1).add_after_run_hook(hook2)
 
         assert result == crons_instance
 
     @pytest.mark.asyncio
     async def test_start_scheduler(self, crons_instance):
         """Test starting the scheduler."""
+
         @crons_instance.cron("* * * * *", name="job1")
         def job1():
             pass
@@ -138,6 +140,7 @@ class TestCronsScheduler:
     @pytest.mark.asyncio
     async def test_stop_scheduler(self, crons_instance):
         """Test stopping the scheduler."""
+
         @crons_instance.cron("* * * * *", name="job1")
         def job1():
             pass
@@ -150,6 +153,7 @@ class TestCronsScheduler:
     @pytest.mark.asyncio
     async def test_start_already_running(self, crons_instance):
         """Test starting scheduler when already running."""
+
         @crons_instance.cron("* * * * *", name="job1")
         def job1():
             pass

--- a/tests/test_state_backend.py
+++ b/tests/test_state_backend.py
@@ -1,4 +1,5 @@
 """Tests for state backend implementations."""
+
 import asyncio
 from datetime import datetime, timedelta
 
@@ -97,8 +98,7 @@ class TestSQLiteStateBackend:
         duration = 5.0
 
         await sqlite_backend.log_job_execution(
-            job_name, instance_id, "completed",
-            start_time, end_time, duration
+            job_name, instance_id, "completed", start_time, end_time, duration
         )
 
         # Verify the log was created (by checking no exception was raised)
@@ -115,8 +115,7 @@ class TestSQLiteStateBackend:
         error_msg = "Job failed with error"
 
         await sqlite_backend.log_job_execution(
-            job_name, instance_id, "failed",
-            start_time, end_time, duration, error_msg
+            job_name, instance_id, "failed", start_time, end_time, duration, error_msg
         )
 
         # Verify the log was created
@@ -124,6 +123,7 @@ class TestSQLiteStateBackend:
     @pytest.mark.asyncio
     async def test_concurrent_writes(self, sqlite_backend):
         """Test concurrent writes to the database."""
+
         async def write_job(job_num):
             await sqlite_backend.set_last_run(f"job_{job_num}", datetime.now())
 

--- a/tests/test_state_backend_sqlalchemy.py
+++ b/tests/test_state_backend_sqlalchemy.py
@@ -1,0 +1,356 @@
+"""Tests for SQLAlchemy state backend — sync and async engines."""
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+@pytest.fixture
+def sa_sync_engine(temp_db):
+    """Sync SQLite in-memory engine."""
+    sqlalchemy = pytest.importorskip("sqlalchemy", reason="pip install fastapi-crons[sqlalchemy]")
+    engine = sqlalchemy.create_engine(
+        f"sqlite:///{temp_db}",
+    )
+    yield engine
+    engine.dispose()
+
+
+@pytest.fixture
+async def sa_async_engine(temp_db):
+    """Async SQLite in-memory engine (requires aiosqlite)."""
+    sqlalchemy = pytest.importorskip(
+        "sqlalchemy.ext.asyncio", reason="pip install fastapi-crons[sqlalchemy]"
+    )
+    engine = sqlalchemy.create_async_engine(
+        f"sqlite+aiosqlite:///{temp_db}",
+    )
+    yield engine
+    await engine.dispose()
+
+
+@pytest.fixture
+def sqlalchemy_backend_sync(sa_sync_engine):
+    """SQLAlchemyStateBackend wrapping a sync engine."""
+    from fastapi_crons.state.sqlalchemy import SQLAlchemyStateBackend
+
+    return SQLAlchemyStateBackend(sa_sync_engine, create_tables=True)
+
+
+@pytest.fixture
+async def sqlalchemy_backend_async(sa_async_engine):
+    """SQLAlchemyStateBackend wrapping an async engine."""
+    from fastapi_crons.state.sqlalchemy import SQLAlchemyStateBackend
+
+    return SQLAlchemyStateBackend(sa_async_engine, create_tables=True)
+
+
+class TestSQLAlchemyStateBackendAsync:
+    """
+    Mirror of TestSQLiteStateBackend using an async SQLAlchemy engine.
+    Ensures SQLAlchemyStateBackend is a drop-in replacement.
+    """
+
+    @pytest.mark.asyncio
+    async def test_set_and_get_last_run(self, sqlalchemy_backend_async):
+        now = _now()
+        await sqlalchemy_backend_async.set_last_run("job_a", now)
+        result = await sqlalchemy_backend_async.get_last_run("job_a")
+        assert result == now.isoformat()
+
+    @pytest.mark.asyncio
+    async def test_get_nonexistent_job_last_run(self, sqlalchemy_backend_async):
+        result = await sqlalchemy_backend_async.get_last_run("ghost_job")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_update_last_run(self, sqlalchemy_backend_async):
+        first = _now()
+        second = first + timedelta(minutes=5)
+
+        await sqlalchemy_backend_async.set_last_run("job_a", first)
+        await sqlalchemy_backend_async.set_last_run("job_a", second)
+
+        result = await sqlalchemy_backend_async.get_last_run("job_a")
+        assert result == second.isoformat()
+
+    @pytest.mark.asyncio
+    async def test_get_all_jobs(self, sqlalchemy_backend_async):
+        now = _now()
+        await sqlalchemy_backend_async.set_last_run("job_a", now)
+        await sqlalchemy_backend_async.set_last_run("job_b", now + timedelta(minutes=1))
+
+        jobs = await sqlalchemy_backend_async.get_all_jobs()
+        names = [j[0] for j in jobs]
+
+        assert "job_a" in names
+        assert "job_b" in names
+        assert names == sorted(names)
+
+    @pytest.mark.asyncio
+    async def test_set_job_status_running(self, sqlalchemy_backend_async):
+        await sqlalchemy_backend_async.set_job_status("job_a", "running", "inst-1")
+        status = await sqlalchemy_backend_async.get_job_status("job_a")
+
+        assert status is not None
+        assert status["status"] == "running"
+        assert status["instance_id"] == "inst-1"
+        assert status["started_at"] is not None
+
+    @pytest.mark.asyncio
+    async def test_update_job_status(self, sqlalchemy_backend_async):
+        await sqlalchemy_backend_async.set_job_status("job_a", "running", "inst-1")
+        await sqlalchemy_backend_async.set_job_status("job_a", "completed", "inst-1")
+
+        status = await sqlalchemy_backend_async.get_job_status("job_a")
+        assert status["status"] == "completed"
+
+    @pytest.mark.asyncio
+    async def test_started_at_preserved_on_completion(self, sqlalchemy_backend_async):
+        """
+        started_at must remain unchanged after running -> completed/failed.
+        This is the specific behavior of our partial upsert.
+        """
+        await sqlalchemy_backend_async.set_job_status("job_a", "running", "inst-1")
+        status_running = await sqlalchemy_backend_async.get_job_status("job_a")
+        started_at_original = status_running["started_at"]
+
+        await sqlalchemy_backend_async.set_job_status("job_a", "completed", "inst-1")
+        status_completed = await sqlalchemy_backend_async.get_job_status("job_a")
+
+        assert status_completed["started_at"] == started_at_original
+
+    @pytest.mark.asyncio
+    async def test_started_at_preserved_on_failure(self, sqlalchemy_backend_async):
+        await sqlalchemy_backend_async.set_job_status("job_a", "running", "inst-1")
+        status_running = await sqlalchemy_backend_async.get_job_status("job_a")
+        started_at_original = status_running["started_at"]
+
+        await sqlalchemy_backend_async.set_job_status("job_a", "failed", "inst-1")
+        status_failed = await sqlalchemy_backend_async.get_job_status("job_a")
+
+        assert status_failed["started_at"] == started_at_original
+
+    @pytest.mark.asyncio
+    async def test_get_nonexistent_job_status(self, sqlalchemy_backend_async):
+        status = await sqlalchemy_backend_async.get_job_status("ghost_job")
+        assert status is None
+
+    @pytest.mark.asyncio
+    async def test_log_job_execution_completed(self, sqlalchemy_backend_async):
+        start = _now()
+        end = start + timedelta(seconds=5)
+        await sqlalchemy_backend_async.log_job_execution(
+            "job_a", "inst-1", "completed", start, end, 5.0
+        )
+
+    @pytest.mark.asyncio
+    async def test_log_job_execution_with_error(self, sqlalchemy_backend_async):
+        start = _now()
+        end = start + timedelta(seconds=2)
+        await sqlalchemy_backend_async.log_job_execution(
+            "job_a", "inst-1", "failed", start, end, 2.0, "Something exploded"
+        )
+
+    @pytest.mark.asyncio
+    async def test_log_job_execution_no_completed_at(self, sqlalchemy_backend_async):
+        """completed_at and duration are optional."""
+        await sqlalchemy_backend_async.log_job_execution("job_a", "inst-1", "failed", _now())
+
+    @pytest.mark.asyncio
+    async def test_tables_created_once(self, sqlalchemy_backend_async):
+        """_ensure_tables must execute only once despite concurrent calls."""
+        await asyncio.gather(
+            sqlalchemy_backend_async.set_last_run("job_a", _now()),
+            sqlalchemy_backend_async.set_last_run("job_b", _now()),
+            sqlalchemy_backend_async.set_last_run("job_c", _now()),
+        )
+        assert sqlalchemy_backend_async._tables_created is True
+
+    @pytest.mark.asyncio
+    async def test_concurrent_writes(self, sqlalchemy_backend_async):
+        """10 concurrent writes must not raise an exception."""
+        await asyncio.gather(
+            *[sqlalchemy_backend_async.set_last_run(f"job_{i}", _now()) for i in range(10)]
+        )
+        jobs = await sqlalchemy_backend_async.get_all_jobs()
+        assert len(jobs) == 10
+
+    @pytest.mark.asyncio
+    async def test_engine_detection_async(self, sqlalchemy_backend_async):
+        assert sqlalchemy_backend_async._is_async is True
+        assert sqlalchemy_backend_async._dialect == "sqlite"
+
+
+class TestSQLAlchemyStateBackendSync:
+    """
+    Same suite as the async version but with a synchronous Engine.
+    Validates that the asyncio.to_thread path works correctly.
+    """
+
+    @pytest.mark.asyncio
+    async def test_set_and_get_last_run(self, sqlalchemy_backend_sync):
+        now = _now()
+        await sqlalchemy_backend_sync.set_last_run("job_a", now)
+        result = await sqlalchemy_backend_sync.get_last_run("job_a")
+        assert result == now.isoformat()
+
+    @pytest.mark.asyncio
+    async def test_get_nonexistent_job_last_run(self, sqlalchemy_backend_sync):
+        result = await sqlalchemy_backend_sync.get_last_run("ghost_job")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_update_last_run(self, sqlalchemy_backend_sync):
+        first = _now()
+        second = first + timedelta(minutes=5)
+
+        await sqlalchemy_backend_sync.set_last_run("job_a", first)
+        await sqlalchemy_backend_sync.set_last_run("job_a", second)
+
+        result = await sqlalchemy_backend_sync.get_last_run("job_a")
+        assert result == second.isoformat()
+
+    @pytest.mark.asyncio
+    async def test_get_all_jobs(self, sqlalchemy_backend_sync):
+        now = _now()
+        await sqlalchemy_backend_sync.set_last_run("job_a", now)
+        await sqlalchemy_backend_sync.set_last_run("job_b", now + timedelta(minutes=1))
+
+        jobs = await sqlalchemy_backend_sync.get_all_jobs()
+        names = [j[0] for j in jobs]
+
+        assert "job_a" in names
+        assert "job_b" in names
+        assert names == sorted(names)
+
+    @pytest.mark.asyncio
+    async def test_set_job_status_running(self, sqlalchemy_backend_sync):
+        await sqlalchemy_backend_sync.set_job_status("job_a", "running", "inst-1")
+        status = await sqlalchemy_backend_sync.get_job_status("job_a")
+
+        assert status is not None
+        assert status["status"] == "running"
+        assert status["instance_id"] == "inst-1"
+        assert status["started_at"] is not None
+
+    @pytest.mark.asyncio
+    async def test_update_job_status(self, sqlalchemy_backend_sync):
+        await sqlalchemy_backend_sync.set_job_status("job_a", "running", "inst-1")
+        await sqlalchemy_backend_sync.set_job_status("job_a", "completed", "inst-1")
+
+        status = await sqlalchemy_backend_sync.get_job_status("job_a")
+        assert status["status"] == "completed"
+
+    @pytest.mark.asyncio
+    async def test_started_at_preserved_on_completion(self, sqlalchemy_backend_sync):
+        await sqlalchemy_backend_sync.set_job_status("job_a", "running", "inst-1")
+        started_at_original = (await sqlalchemy_backend_sync.get_job_status("job_a"))["started_at"]
+
+        await sqlalchemy_backend_sync.set_job_status("job_a", "completed", "inst-1")
+        status = await sqlalchemy_backend_sync.get_job_status("job_a")
+
+        assert status["started_at"] == started_at_original
+
+    @pytest.mark.asyncio
+    async def test_started_at_preserved_on_failure(self, sqlalchemy_backend_sync):
+        await sqlalchemy_backend_sync.set_job_status("job_a", "running", "inst-1")
+        started_at_original = (await sqlalchemy_backend_sync.get_job_status("job_a"))["started_at"]
+
+        await sqlalchemy_backend_sync.set_job_status("job_a", "failed", "inst-1")
+        status = await sqlalchemy_backend_sync.get_job_status("job_a")
+
+        assert status["started_at"] == started_at_original
+
+    @pytest.mark.asyncio
+    async def test_get_nonexistent_job_status(self, sqlalchemy_backend_sync):
+        status = await sqlalchemy_backend_sync.get_job_status("ghost_job")
+        assert status is None
+
+    @pytest.mark.asyncio
+    async def test_log_job_execution_completed(self, sqlalchemy_backend_sync):
+        start = _now()
+        end = start + timedelta(seconds=5)
+        await sqlalchemy_backend_sync.log_job_execution(
+            "job_a", "inst-1", "completed", start, end, 5.0
+        )
+
+    @pytest.mark.asyncio
+    async def test_log_job_execution_with_error(self, sqlalchemy_backend_sync):
+        start = _now()
+        end = start + timedelta(seconds=2)
+        await sqlalchemy_backend_sync.log_job_execution(
+            "job_a", "inst-1", "failed", start, end, 2.0, "Something exploded"
+        )
+
+    @pytest.mark.asyncio
+    async def test_concurrent_writes(self, sqlalchemy_backend_sync):
+        """
+        For the sync backend, calls are serialized via asyncio.to_thread.
+        We verify that there is no race condition on _ensure_tables.
+        """
+        await asyncio.gather(
+            *[sqlalchemy_backend_sync.set_last_run(f"job_{i}", _now()) for i in range(10)]
+        )
+        jobs = await sqlalchemy_backend_sync.get_all_jobs()
+        assert len(jobs) == 10
+
+    @pytest.mark.asyncio
+    async def test_engine_detection_sync(self, sqlalchemy_backend_sync):
+        assert sqlalchemy_backend_sync._is_async is False
+        assert sqlalchemy_backend_sync._dialect == "sqlite"
+
+
+class TestSQLAlchemyStateBackendNoAutoCreate:
+    """
+    Verifies that create_tables=False does not create tables automatically.
+    The dev is responsible for creating them via Alembic.
+    """
+
+    @pytest.mark.asyncio
+    async def test_no_auto_create_raises_on_missing_table(self, sa_async_engine):
+        from sqlalchemy.exc import OperationalError
+
+        from fastapi_crons.state.sqlalchemy import SQLAlchemyStateBackend
+
+        backend = SQLAlchemyStateBackend(sa_async_engine, create_tables=False)
+
+        with pytest.raises(OperationalError):
+            await backend.set_last_run("job_a", _now())
+
+    @pytest.mark.asyncio
+    async def test_no_auto_create_works_after_manual_create(self, sa_async_engine):
+        from fastapi_crons.state.sqlalchemy import SQLAlchemyStateBackend, cron_metadata
+
+        async with sa_async_engine.begin() as conn:
+            await conn.run_sync(cron_metadata.create_all)
+
+        backend = SQLAlchemyStateBackend(sa_async_engine, create_tables=False)
+        now = _now()
+        await backend.set_last_run("job_a", now)
+        result = await backend.get_last_run("job_a")
+        assert result == now.isoformat()
+
+
+class TestSQLModelStateBackendAlias:
+    """SQLModelStateBackend is a pure alias — same class, same behavior."""
+
+    def test_alias_is_same_class(self):
+        cron_sqlalchemy = pytest.importorskip(
+            "fastapi_crons.state.sqlalchemy", reason="pip install fastapi-crons[sqlalchemy]"
+        )
+        assert cron_sqlalchemy.SQLModelStateBackend is cron_sqlalchemy.SQLAlchemyStateBackend
+
+    @pytest.mark.asyncio
+    async def test_alias_functional(self, sa_async_engine):
+        from fastapi_crons.state.sqlalchemy import SQLModelStateBackend
+
+        backend = SQLModelStateBackend(sa_async_engine, create_tables=True)
+        now = _now()
+        await backend.set_last_run("job_a", now)
+        assert await backend.get_last_run("job_a") == now.isoformat()


### PR DESCRIPTION
## Description

Refactor fastapi_crons/state.py and fastapi_crons/locking.py into packages to accommodate new backends while preserving all existing imports and behavior.

New fastapi_crons/state/sqlalchemy.py:
- SQLAlchemyStateBackend: supports sync and async SQLAlchemy engines
- SQLModelStateBackend: alias for SQLModel users (zero duplication)
- Dialect-native upsert: PostgreSQL, SQLite, MySQL/MariaDB
- cron_metadata exposed for Alembic integration
- create_tables=False for Alembic-managed schemas

New fastapi_crons/locking/sqlalchemy.py:
- SQLAlchemyLockBackend: table-based, compatible with SQLite/PostgreSQL/MySQL
- PostgreSQLAdvisoryLockBackend: pg_advisory_lock, no table required
- cron_locks_metadata exposed for Alembic integration
- create_tables=False for Alembic-managed schemas

Tests:
- tests/test_state_backend_sqlalchemy.py: async/sync engines, concurrent writes, create_tables=True/False, SQLModelStateBackend alias
- tests/test_locking_sqlalchemy.py: acquire/release/renew/expire, async/sync engines, create_tables=True/False

sqlalchemy and sqlmodel remain optional extras in pyproject.toml. Tests skip automatically when extras are not installed.

Fixes #16

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Install extras and run:
```bash
pip install -e ".[dev,sqlalchemy]"
pytest tests/test_state_backend_sqlalchemy.py
pytest tests/test_locking_sqlalchemy.py
```

- [x] SQLAlchemyStateBackend sync engine (SQLite file)
- [x] SQLAlchemyStateBackend async engine (SQLite in-memory)
- [x] SQLAlchemyLockBackend async/sync
- [x] create_tables=False (Alembic mode)
- [x] Concurrent writes

## Checklist
- [x] Code follows style guidelines
- [x] Self-review performed
- [x] Code commented in hard-to-understand areas
- [x] Tests added and passing
- [x] No new warnings

## Additional Context
Note: pre-existing mypy errors on unchanged files were not addressed in this PR.

### Usage
```python
from sqlalchemy.ext.asyncio import create_async_engine
from fastapi_crons.state.sqlalchemy import SQLAlchemyStateBackend
from fastapi_crons.locking.sqlalchemy import SQLAlchemyLockBackend

engine  = create_async_engine("postgresql+asyncpg://...")
crons   = Crons(app, state_backend=SQLAlchemyStateBackend(engine))
```

### Alembic
```python
from fastapi_crons.state.sqlalchemy import cron_metadata
from fastapi_crons.locking.sqlalchemy import cron_locks_metadata
target_metadata = [Base.metadata, cron_metadata, cron_locks_metadata]
```