### PR TITLE
feat: get_cron_router uses existing crons if possible

### DIFF
--- a/fastapi_crons/endpoints.py
+++ b/fastapi_crons/endpoints.py
@@ -6,8 +6,7 @@ from datetime import datetime, timezone
 from fastapi import APIRouter, HTTPException
 
 from . import __version__
-from .config import CronConfig
-from .scheduler import Crons
+from .scheduler import get_crons
 
 # Track server start time for uptime calculation
 _server_start_time: float | None = None
@@ -22,8 +21,8 @@ def get_cron_router():
     router = APIRouter()
 
     # Initialize configuration and scheduler
-    config = CronConfig()
-    crons = Crons(config=config)
+    crons = get_crons()
+    config = crons.config
 
     async def get_all_jobs():
         if not crons:


### PR DESCRIPTION
## Description

Currently, get_cron_router() always creates a new crons. Using get_crons() instead allows endpoints to serve information from the existing crons if possible or create a new one.

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests passed locally with my changes
- [ ] Any dependent changes have been merged and published

