### PR TITLE
fix: install the fastapi-crons console script (#18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,21 @@ Jobs can be:
 fastapi-crons list
 
 # Manually run a specific job
-fastapi-crons run_job <job_name>
+# -i imports the module that registers your jobs (repeatable)
+fastapi-crons run-job <job_name> -i myapp.jobs
+
+# Show overall system status
+fastapi-crons status
+
+# Inspect / change configuration
+fastapi-crons config-show
+fastapi-crons config-set <key> <value>
+
+# Run the scheduler outside of a FastAPI app
+fastapi-crons start-scheduler -i myapp.jobs
+
+# See every command and its options
+fastapi-crons --help
 ```
 
 >

--- a/fastapi_crons/cli.py
+++ b/fastapi_crons/cli.py
@@ -1,6 +1,10 @@
 import asyncio
+import importlib
 import inspect
+import os
+import sys
 from datetime import datetime, timezone
+from typing import Annotated
 
 import typer
 from rich.console import Console
@@ -59,6 +63,82 @@ def get_state_backend():
     return state_backend
 
 
+async def _aclose(obj) -> None:
+    """Close a backend or client, whichever close method it happens to expose."""
+    if obj is None:
+        return
+    closer = getattr(obj, "aclose", None) or getattr(obj, "close", None)
+    if closer is None:
+        return
+    try:
+        result = closer()
+        if inspect.isawaitable(result):
+            await result
+    except Exception:
+        # Teardown must never mask the command's own output or exit code.
+        pass
+
+
+async def _close_backends() -> None:
+    """Release the connections opened by get_state_backend/get_lock_manager."""
+    global state_backend, lock_manager
+
+    backend, manager = state_backend, lock_manager
+    state_backend = lock_manager = None
+
+    if backend is not None:
+        # SQLiteStateBackend.close() closes the connection; RedisStateBackend
+        # has no close() of its own, so fall back to the client it wraps.
+        if hasattr(backend, "close"):
+            await _aclose(backend)
+        else:
+            await _aclose(getattr(backend, "redis", None))
+
+    if manager is not None:
+        await _aclose(getattr(getattr(manager, "backend", None), "redis", None))
+
+
+def import_job_modules(modules: list[str] | None) -> None:
+    """Import the modules that register the user's jobs.
+
+    Jobs register themselves into the process-global Crons instance when their
+    module is imported, so a standalone CLI process sees an empty registry
+    until those modules are loaded. A console script also starts with its own
+    bin/ directory on sys.path rather than the working directory, so add the
+    latter to make `-i myapp.jobs` work from a project root.
+    """
+    if not modules:
+        return
+
+    cwd = os.getcwd()
+    if cwd not in sys.path:
+        sys.path.insert(0, cwd)
+
+    for module in modules:
+        try:
+            importlib.import_module(module)
+        except Exception as e:
+            console.print(f"[red]Could not import '{module}': {e}[/red]")
+            raise typer.Exit(code=1) from e
+
+
+def run_async(main) -> None:
+    """Run a command coroutine and then tear down its backends.
+
+    aiosqlite services each connection from a non-daemon worker thread, so a
+    command that opens the SQLite backend without closing it prints its output
+    and then hangs at interpreter shutdown forever instead of exiting.
+    """
+
+    async def runner():
+        try:
+            await main()
+        finally:
+            await _close_backends()
+
+    asyncio.run(runner())
+
+
 def get_lock_manager():
     """Get the appropriate lock manager based on configuration."""
     global lock_manager
@@ -91,7 +171,10 @@ def get_lock_manager():
     return lock_manager
 
 
-@cli.command()
+# Command names are pinned explicitly: Typer derives them from the function
+# name, and that mapping has changed between releases (underscores used to be
+# kept, now they become dashes). The documented names should not move with it.
+@cli.command("config-set")
 def config_set(
     key: str = typer.Argument(..., help="Configuration key"),
     value: str = typer.Argument(..., help="Configuration value"),
@@ -114,7 +197,7 @@ def config_set(
         console.print("Available keys:", list(config.__dict__.keys()))
 
 
-@cli.command()
+@cli.command("config-show")
 def config_show():
     """Show current configuration."""
     table = Table(title="Current Configuration")
@@ -127,7 +210,7 @@ def config_show():
     console.print(table)
 
 
-@cli.command()
+@cli.command("list")
 def list_jobs():
     """List all registered jobs and their status."""
 
@@ -169,7 +252,7 @@ def list_jobs():
                 progress.remove_task(task)
                 console.print(f"[red]Error loading jobs: {e}[/red]")
 
-    asyncio.run(run())
+    run_async(run)
 
 
 async def execute_hook(hook, job_name: str, context: dict):
@@ -183,12 +266,21 @@ async def execute_hook(hook, job_name: str, context: dict):
         console.print(f"[red][Hook Error][{job_name}] {e}[/red]")
 
 
-@cli.command()
+@cli.command("run-job")
 def run_job(
     name: str = typer.Argument(..., help="Job name to run"),
     force: bool = typer.Option(False, "--force", "-f", help="Force run even if locked"),
+    modules: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--import",
+            "-i",
+            help="Module that registers your jobs, e.g. myapp.jobs (repeatable)",
+        ),
+    ] = None,
 ):
     """Manually run a specific job."""
+    import_job_modules(modules)
 
     async def run():
         from .scheduler import Crons
@@ -224,6 +316,10 @@ def run_job(
             SpinnerColumn(), TextColumn("[progress.description]{task.description}"), console=console
         ) as progress:
             task = progress.add_task(f"Running job '{name}'...", total=None)
+
+            # Bound before the try so the finally below can read it even when
+            # acquire_lock itself raises (Redis down, for instance).
+            lock_id = None
 
             try:
                 # Acquire lock
@@ -333,10 +429,10 @@ def run_job(
                 if lock_id:
                     await lock_mgr.release_lock(f"job:{name}")
 
-    asyncio.run(run())
+    run_async(run)
 
 
-@cli.command()
+@cli.command("status")
 def status():
     """Show overall system status."""
 
@@ -379,16 +475,26 @@ def status():
         except Exception as e:
             console.print(f"[red]Error getting status: {e}[/red]")
 
-    asyncio.run(run())
+    run_async(run)
 
 
-@cli.command()
+@cli.command("start-scheduler")
 def start_scheduler(
     daemon: bool = typer.Option(False, "--daemon", "-d", help="Run as daemon"),
     log_level: str = typer.Option("INFO", "--log-level", help="Log level"),
+    modules: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--import",
+            "-i",
+            help="Module that registers your jobs, e.g. myapp.jobs (repeatable)",
+        ),
+    ] = None,
 ):
     """Start the cron scheduler."""
     import logging
+
+    import_job_modules(modules)
 
     # Configure logging
     logging.basicConfig(
@@ -434,12 +540,12 @@ def start_scheduler(
             console.print("[green]Scheduler stopped[/green]")
 
     try:
-        asyncio.run(run())
+        run_async(run)
     except KeyboardInterrupt:
         console.print("\n[yellow]Interrupted[/yellow]")
 
 
-@cli.command()
+@cli.command("logs")
 def logs(
     job_name: str | None = typer.Option(None, "--job", "-j", help="Filter by job name"),
     limit: int = typer.Option(50, "--limit", "-l", help="Number of log entries to show"),
@@ -454,7 +560,7 @@ def logs(
         # For now, show a placeholder message
         console.print("[yellow]Log viewing feature coming soon[/yellow]")
 
-    asyncio.run(run())
+    run_async(run)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,12 @@ dashboard = []
 "Homepage" = "https://github.com/me-umar/fastapi-crons"
 "Documentation" = "https://crons.darcode.dev"
 
+# cli.py has always defined a full Typer app, but without this section pip
+# installs no console script at all, so the documented `fastapi-crons ...`
+# commands were only reachable via `python -m fastapi_crons.cli`.
+[project.scripts]
+fastapi-crons = "fastapi_crons.cli:cli"
+
 [tool.setuptools.packages.find]
 where = ["."]
 # Without an explicit include, tests/, examples/ and scripts/ get published as

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,10 +1,11 @@
 """Tests for the fastapi-crons console script and CLI commands."""
 
+import re
 import threading
+from importlib import metadata
 from pathlib import Path
 
 import pytest
-import tomllib
 from typer.testing import CliRunner
 
 import fastapi_crons.cli as cli_module
@@ -26,16 +27,40 @@ def _reset_cli_backends(temp_db):
     cli_module.lock_manager = None
 
 
+def declared_console_scripts() -> dict[str, str]:
+    """The console scripts fastapi-crons declares.
+
+    Read from installed metadata when the package is installed, which is what
+    actually decides whether pip creates the script. Fall back to pyproject.toml
+    for a plain source checkout. tomllib is deliberately not used: it only
+    exists on 3.11+ and this package supports 3.10.
+    """
+    try:
+        dist = metadata.distribution("fastapi-crons")
+    except metadata.PackageNotFoundError:
+        dist = None
+
+    if dist is not None:
+        return {ep.name: ep.value for ep in dist.entry_points if ep.group == "console_scripts"}
+
+    pyproject = Path(__file__).resolve().parent.parent / "pyproject.toml"
+    section = re.search(
+        r"^\[project\.scripts\]\s*$(.*?)(?=^\[|\Z)",
+        pyproject.read_text(encoding="utf-8"),
+        re.MULTILINE | re.DOTALL,
+    )
+    if section is None:
+        return {}
+
+    return dict(re.findall(r'^\s*"?([\w.-]+)"?\s*=\s*"([^"]+)"', section.group(1), re.MULTILINE))
+
+
 class TestConsoleScript:
     """The entry point declared in pyproject.toml (issue #18)."""
 
     def test_console_script_is_declared(self):
-        """pyproject.toml must declare the documented fastapi-crons script."""
-        pyproject = Path(__file__).resolve().parent.parent / "pyproject.toml"
-        with pyproject.open("rb") as fh:
-            data = tomllib.load(fh)
-
-        assert data["project"]["scripts"]["fastapi-crons"] == "fastapi_crons.cli:cli"
+        """The documented fastapi-crons script must be declared."""
+        assert declared_console_scripts().get("fastapi-crons") == "fastapi_crons.cli:cli"
 
     def test_entry_point_target_is_callable(self):
         """The path in the entry point must resolve to the Typer app."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,107 @@
+"""Tests for the fastapi-crons console script and CLI commands."""
+
+import threading
+from pathlib import Path
+
+import pytest
+import tomllib
+from typer.testing import CliRunner
+
+import fastapi_crons.cli as cli_module
+from fastapi_crons.cli import cli
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _reset_cli_backends(temp_db):
+    """Point the CLI at a throwaway database and clear its cached backends."""
+    original_path = cli_module.config.sqlite_db_path
+    cli_module.config.sqlite_db_path = temp_db
+    cli_module.state_backend = None
+    cli_module.lock_manager = None
+    yield
+    cli_module.config.sqlite_db_path = original_path
+    cli_module.state_backend = None
+    cli_module.lock_manager = None
+
+
+class TestConsoleScript:
+    """The entry point declared in pyproject.toml (issue #18)."""
+
+    def test_console_script_is_declared(self):
+        """pyproject.toml must declare the documented fastapi-crons script."""
+        pyproject = Path(__file__).resolve().parent.parent / "pyproject.toml"
+        with pyproject.open("rb") as fh:
+            data = tomllib.load(fh)
+
+        assert data["project"]["scripts"]["fastapi-crons"] == "fastapi_crons.cli:cli"
+
+    def test_entry_point_target_is_callable(self):
+        """The path in the entry point must resolve to the Typer app."""
+        assert callable(cli)
+
+
+class TestCommandNames:
+    """Command names are pinned, so the documented ones cannot drift."""
+
+    @pytest.mark.parametrize(
+        "name",
+        ["list", "run-job", "status", "config-set", "config-show", "start-scheduler", "logs"],
+    )
+    def test_command_is_registered(self, name):
+        result = runner.invoke(cli, ["--help"])
+
+        assert result.exit_code == 0
+        assert name in result.stdout
+
+
+class TestCommands:
+    """Commands run to completion and release their backends."""
+
+    def test_list_with_no_jobs(self):
+        result = runner.invoke(cli, ["list"])
+
+        assert result.exit_code == 0
+        assert "No jobs found" in result.stdout
+
+    def test_status(self):
+        result = runner.invoke(cli, ["status"])
+
+        assert result.exit_code == 0
+        assert "System Status" in result.stdout
+
+    def test_config_show(self):
+        result = runner.invoke(cli, ["config-show"])
+
+        assert result.exit_code == 0
+        assert "sqlite_db_path" in result.stdout
+
+    def test_run_job_with_unknown_name(self):
+        result = runner.invoke(cli, ["run-job", "does-not-exist"])
+
+        assert result.exit_code == 0
+        assert "not found" in result.stdout
+
+    def test_run_job_with_unimportable_module(self):
+        result = runner.invoke(cli, ["run-job", "whatever", "-i", "no_such_module_here"])
+
+        assert result.exit_code == 1
+        assert "Could not import" in result.stdout
+
+    def test_backends_are_closed_after_a_command(self):
+        """aiosqlite's worker thread is not a daemon: an unclosed connection
+        keeps the interpreter alive forever after the command has printed."""
+        before = {t.name for t in threading.enumerate()}
+
+        result = runner.invoke(cli, ["list"])
+
+        assert result.exit_code == 0
+        assert cli_module.state_backend is None
+
+        leaked = [
+            t
+            for t in threading.enumerate()
+            if t.name not in before and t.is_alive() and not t.daemon
+        ]
+        assert leaked == []


### PR DESCRIPTION
Fixes #18

## The reported bug

`fastapi_crons/cli.py` has always defined a full Typer app, but `pyproject.toml` declared no `[project.scripts]` section, so `pip install fastapi-crons` installed no console script at all. The commands documented in the README were only reachable via `python -m fastapi_crons.cli`.

## What else this uncovered

Verifying the entry point in a clean venv surfaced two problems that would have shipped a broken command:

- **Command names did not match the docs.** Typer derives command names from function names, and that mapping now turns underscores into dashes, so `list_jobs` would have shipped as `list-jobs` — the documented `fastapi-crons list` would have errored. Names are now pinned explicitly (`@cli.command("list")`), so they cannot drift with future Typer releases.
- **Every command hung forever.** `fastapi-crons list` printed its output and then never exited: aiosqlite services each connection from a non-daemon worker thread, and the CLI never closed the backend. Commands now run through `run_async()`, which tears down the state backend and lock manager in a `finally`.

## One addition beyond the literal issue

`run-job` and `start-scheduler` construct a `Crons()` in a fresh process, but jobs only register themselves when their defining module is imported — so both commands found an empty registry every time, regardless of arguments. Both now accept a repeatable `--import/-i`:

```bash
fastapi-crons run-job hello -i myapp.jobs
```

Happy to drop this and ship the entry point alone if you would rather handle job discovery separately.

Also binds `lock_id` before the `try` in `run-job`, so the `finally` no longer raises `NameError` and masks the real error when `acquire_lock` fails.

## Verification

- New `tests/test_cli.py` (15 tests): entry-point declaration, every command name, command execution, and a regression test for the thread leak. Confirmed that test fails against the pre-fix behavior — the process leaks `_connection_worker_thread` and times out at exit.
- Full suite: **131 passed**.
- `ruff check` and `ruff format --check` clean.
- Manually exercised every command from a `pip install`-ed venv, including a real job execution round-trip.
